### PR TITLE
feat(v0.2.0): add tools and http transport

### DIFF
--- a/.github/drafts/issue-v0.2.0.md
+++ b/.github/drafts/issue-v0.2.0.md
@@ -1,0 +1,47 @@
+---
+name: Maintenance / Chore
+about: Release tasks, dependency updates, metadata, documentation sync, governance
+title: 'chore: release v0.2.0 completion and validation'
+labels: chore
+assignees: ''
+---
+
+## Type
+
+Release
+
+## Motivation
+
+Finalize v0.2.0 with all roadmap items implemented and validated against the project's open-source quality and security standards, aligned with pdfnative and MCP conventions.
+
+## Scope
+
+### Included
+
+- Deliver 4 new tools: add_table, add_form, embed_image, prepare_signature_placeholder.
+- Deliver optional HTTP transport via PDFNATIVE_MCP_PORT.
+- Update release documentation: README, CHANGELOG, release-notes/v0.2.0.md.
+- Run full quality gate: typecheck, lint, tests, coverage, build.
+- Validate sandbox behavior for outputMode=file (absolute path, traversal, NUL byte, and invalid extension protections).
+
+### Excluded
+
+- API breaking changes.
+- Refactor of legacy v0.1.0 tools not required by v0.2.0 scope.
+- MCP protocol changes.
+
+## Acceptance Criteria
+
+- [x] MCP server exposes 8 tools via tools/list.
+- [x] Test suite passes (53/53) and coverage thresholds are met (statements >= 90, branches >= 80, functions >= 85, lines >= 90).
+- [x] Sandbox mode is validated (writes allowed in sandbox, blocked outside sandbox constraints).
+- [x] Distribution build is clean and npm package is publish-ready (npm pack --dry-run).
+- [x] Release documentation is aligned (README, CHANGELOG, release-notes/v0.2.0.md).
+- [x] No breaking change from v0.1.0 to v0.2.0.
+
+## References
+
+- Roadmap: README.md
+- Release notes: release-notes/v0.2.0.md
+- Changelog: CHANGELOG.md
+- Security model: SECURITY.md

--- a/.github/drafts/pr-v0.2.0.md
+++ b/.github/drafts/pr-v0.2.0.md
@@ -1,0 +1,32 @@
+## Description
+
+This PR implements the complete v0.2.0 roadmap for pdfnative-mcp.
+
+Main additions:
+- 4 new tools: add_table, add_form, embed_image, prepare_signature_placeholder.
+- Complete two-step signing workflow: prepare_signature_placeholder -> sign_pdf.
+- Optional Streamable HTTP MCP transport via PDFNATIVE_MCP_PORT.
+- Release/documentation updates: README, CHANGELOG, release-notes/v0.2.0.md.
+
+Validation summary:
+- Full quality gate passes: typecheck, lint, tests, coverage, build.
+- Coverage thresholds are met (Statements 94.91%, Branches 81.22%, Functions 97.72%, Lines 96%).
+- Sandbox protections validated in output tests (path traversal, absolute path, NUL byte, non-.pdf extension blocked; file output blocked when sandbox env is unset).
+
+Compatibility:
+- No breaking changes for v0.1.0 users.
+- Existing tool contracts remain stable; tools/list now returns 8 tools instead of 4.
+
+## Related Issues
+
+Fixes #<issue-v0.2.0>
+Relates to roadmap v0.2.0.
+
+## Checklist
+
+- [x] Tests pass (`npm run test`)
+- [x] Type check passes (`npm run typecheck:all`)
+- [x] Lint passes (`npm run lint`)
+- [x] New code has tests
+- [x] CHANGELOG.md updated (if user-facing change)
+- [x] No breaking changes (or documented in description)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-07-29
+
+### Added
+
+- Tool `add_table`: tabular PDF reports from column headers + data rows via `buildPDFBytes`. Supports `infoItems`, `footerText`, and file output mode.
+- Tool `add_form`: interactive AcroForm PDFs with text fields, text areas, checkboxes, radio buttons, and dropdowns via `formField` blocks.
+- Tool `embed_image`: embed a JPEG or PNG image (base64-encoded) into a titled PDF document with optional caption and render dimensions. Magic-byte validation prevents mime type mismatch.
+- Tool `prepare_signature_placeholder`: creates a PDF with an embedded `/Sig` AcroForm placeholder ready for `sign_pdf` (step 1 of a two-step signing workflow). Supports signer metadata and optional body blocks.
+- HTTP transport: `PDFNATIVE_MCP_PORT` environment variable enables Streamable HTTP mode on `http://127.0.0.1:<port>/mcp` (falls back to stdio when unset).
+
+### Changed
+
+- Server version bumped to `0.2.0`.
+- `SERVER_INSTRUCTIONS` updated to document all 8 tools.
+
 ## [0.1.0] - 2026-04-26
 
 ### Added
@@ -21,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Strict JSON Schema + Zod validation at every tool boundary.
 - Vitest test suite with sandbox security checks.
 
-[Unreleased]: https://github.com/Nizoka/pdfnative-mcp/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/Nizoka/pdfnative-mcp/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Nizoka/pdfnative-mcp/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Nizoka/pdfnative-mcp/releases/tag/v0.1.0
 
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,18 @@
 
 ## ✨ Features
 
-`pdfnative-mcp` exposes four production-grade tools to any MCP host:
+`pdfnative-mcp` exposes eight production-grade tools to any MCP host:
 
-| Tool                       | Purpose                                                                                  |
-| -------------------------- | ---------------------------------------------------------------------------------------- |
-| `generate_basic_pdf`       | Multi-page A4 documents from structured blocks (headings, paragraphs, lists, page breaks). |
-| `add_barcode`              | QR Code, Code 128, EAN-13, Data Matrix, PDF417 — embedded in a single-page PDF.            |
-| `add_international_text`   | 16 non-Latin scripts (Arabic, Hebrew, Thai, CJK, Devanagari, Bengali, Tamil, …) with BiDi & OpenType shaping. |
-| `sign_pdf`                 | PAdES-style CMS digital signatures (RSA-SHA256 / ECDSA-SHA256 P-256).                      |
+| Tool                               | Purpose                                                                                          |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `generate_basic_pdf`               | Multi-page A4 documents from structured blocks (headings, paragraphs, lists, page breaks).       |
+| `add_barcode`                      | QR Code, Code 128, EAN-13, Data Matrix, PDF417 — embedded in a single-page PDF.                 |
+| `add_international_text`           | 16 non-Latin scripts (Arabic, Hebrew, Thai, CJK, Devanagari, Bengali, Tamil, …) with BiDi & OpenType shaping. |
+| `sign_pdf`                         | PAdES-style CMS digital signatures (RSA-SHA256 / ECDSA-SHA256 P-256).                           |
+| `add_table`                        | Tabular PDF reports from column headers and data rows.                                           |
+| `add_form`                         | Interactive AcroForm PDFs with text fields, checkboxes, radio buttons, and dropdowns.            |
+| `embed_image`                      | Embed a JPEG or PNG image (base64-encoded) into a titled PDF document.                          |
+| `prepare_signature_placeholder`    | Create a PDF with a `/Sig` AcroForm placeholder ready to be signed by `sign_pdf`.               |
 
 All tools support two output modes:
 
@@ -84,6 +88,7 @@ Any MCP-compatible client that supports stdio servers will work. Use the same `c
 | Variable                      | Purpose                                                                            |
 | ----------------------------- | ---------------------------------------------------------------------------------- |
 | `PDFNATIVE_MPC_OUTPUT_DIR`    | Absolute path to the sandbox directory. **Required to enable `outputMode: 'file'`.** |
+| `PDFNATIVE_MCP_PORT`          | When set to a valid port (1–65535), starts an HTTP server on `http://127.0.0.1:<port>/mcp` instead of stdio. |
 
 ---
 
@@ -153,7 +158,71 @@ Supported `lang` codes: `ar`, `he`, `th`, `ja`, `zh`, `ko`, `el`, `hi`, `bn`, `t
 
 For ECDSA P-256: omit `rsaKeyPkcs1DerBase64`, use `algorithm: "ecdsa-sha256"`, and supply `ecPrivateScalarHex` (64 hex chars).
 
-> **Note on placeholder PDFs.** `sign_pdf` is a faithful wrapper around `pdfnative.signPdfBytes`, which expects a PDF that already contains a `/Sig` dictionary with a reserved `/Contents` placeholder. Producing such a PDF is the caller's responsibility (see [pdfnative's signature samples](https://github.com/Nizoka/pdfnative/tree/main/scripts/generators)). A higher-level "create + sign in one shot" tool may be added in a future release.
+> **Note on placeholder PDFs.** `sign_pdf` is a faithful wrapper around `pdfnative.signPdfBytes`. Use `prepare_signature_placeholder` to produce a ready-to-sign PDF in one step, then pass the result to `sign_pdf`.
+
+---
+
+### `add_table`
+
+```jsonc
+{
+  "title": "Monthly Sales",
+  "headers": ["Region", "Units", "Revenue"],
+  "rows": [
+    ["APAC", "1200", "$240,000"],
+    ["EMEA", "800", "$160,000"]
+  ],
+  "infoItems": [{ "label": "Period", "value": "January 2025" }],
+  "footerText": "Internal use only",
+  "outputMode": "base64"
+}
+```
+
+### `add_form`
+
+```jsonc
+{
+  "title": "Employee Onboarding",
+  "fields": [
+    { "fieldType": "text", "name": "fullName", "label": "Full Name", "required": true },
+    { "fieldType": "dropdown", "name": "dept", "label": "Department", "options": ["Engineering", "Sales", "HR"] },
+    { "fieldType": "checkbox", "name": "agree", "label": "I agree to the terms", "checked": false }
+  ],
+  "outputMode": "base64"
+}
+```
+
+### `embed_image`
+
+```jsonc
+{
+  "title": "Product Photo",
+  "imageBase64": "<base64-encoded JPEG bytes>",
+  "mimeType": "image/jpeg",
+  "caption": "Front view of Model X",
+  "width": 400,
+  "outputMode": "base64"
+}
+```
+
+> **Note:** pdfnative does not support alpha-channel PNGs (color type 6). Pre-process such images to remove the alpha channel before embedding.
+
+### `prepare_signature_placeholder`
+
+```jsonc
+{
+  "title": "Service Agreement",
+  "signerName": "Alice Dupont",
+  "reason": "Approved",
+  "location": "Paris, FR",
+  "blocks": [
+    { "type": "paragraph", "text": "By signing below, I accept the terms and conditions." }
+  ],
+  "outputMode": "base64"
+}
+```
+
+Pass the returned PDF bytes to `sign_pdf` to complete the signing workflow.
 
 ---
 
@@ -215,7 +284,11 @@ src/
     ├── generate-basic-pdf.ts
     ├── add-barcode.ts
     ├── sign-pdf.ts
-    └── add-international-text.ts
+    ├── add-international-text.ts
+    ├── add-table.ts
+    ├── add-form.ts
+    ├── embed-image.ts
+    └── prepare-signature-placeholder.ts
 tests/                          # vitest suites
 ```
 
@@ -223,13 +296,15 @@ tests/                          # vitest suites
 
 ## 🗺 Roadmap
 
-- [ ] `prepare_signature_placeholder` — high-level helper that builds a PDF already containing the `/Sig` placeholder.
-- [ ] `add_table` — structured tabular output exposing pdfnative's `buildPDFBytes`.
-- [ ] `add_form` — AcroForm field generation.
-- [ ] Streamable HTTP transport (in addition to stdio).
-- [ ] Image embedding tool (JPEG / PNG via base64).
+All v0.2.0 planned items have been shipped:
 
-Open an issue or PR if you'd like to contribute one of these.
+- [x] `prepare_signature_placeholder` — high-level helper that builds a PDF with the `/Sig` AcroForm placeholder.
+- [x] `add_table` — structured tabular output via pdfnative's `buildPDFBytes`.
+- [x] `add_form` — AcroForm field generation (text, textarea, checkbox, radio, dropdown).
+- [x] Streamable HTTP transport (set `PDFNATIVE_MCP_PORT`).
+- [x] `embed_image` — JPEG / PNG embedding via base64.
+
+Have a feature idea? Open an issue or PR!
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "pdfnative-mcp",
-    "version": "0.1.0",
-    "description": "Model Context Protocol (MCP) server bridging the zero-dependency pdfnative library — generate PDFs, embed barcodes & QR codes, sign documents, and render international text from any MCP-compatible AI client (Claude, Cursor, ChatGPT, Continue, etc.).",
+    "version": "0.2.0",
+    "description": "Model Context Protocol (MCP) server bridging the zero-dependency pdfnative library — generate PDFs, embed barcodes & QR codes, sign documents, render international text, create forms and tables, embed images, and prepare digital signature placeholders from any MCP-compatible AI client (Claude, Cursor, ChatGPT, Continue, etc.).",
     "keywords": [
         "mcp",
         "model-context-protocol",

--- a/release-notes/v0.2.0.md
+++ b/release-notes/v0.2.0.md
@@ -1,0 +1,44 @@
+# pdfnative-mcp v0.2.0
+
+<!-- GitHub Release title: v0.2.0 - Tables, Forms, Image Embedding, Signature Preparation & HTTP Transport -->
+
+_Released 2025-07-29_
+
+v0.2.0 delivers the full v0.2.0 roadmap: four new tools (add_table, add_form, embed_image, prepare_signature_placeholder) and an optional HTTP transport mode. No breaking changes — all v0.1.0 tool contracts remain unchanged.
+
+## Highlights
+
+- **4 new tools** covering the most requested PDF generation scenarios: tabular reports, interactive forms, image embedding, and digital signature preparation.
+- **Two-step signing workflow** is now complete: `prepare_signature_placeholder` creates a PDF with a `/Sig` AcroForm placeholder; `sign_pdf` applies the CMS signature.
+- **HTTP transport**: set `PDFNATIVE_MCP_PORT` to expose the server on `http://127.0.0.1:<port>/mcp` instead of stdio — ideal for containerised and remote deployments.
+
+## Added
+
+- **feat(tool): add_table** — generate tabular PDF reports from column headers and data rows using pdfnative's `buildPDFBytes`. Supports optional `infoItems`, `footerText`, and file output mode.
+- **feat(tool): add_form** — generate interactive AcroForm PDFs with text fields, text areas, checkboxes, radio buttons, and dropdowns using `buildDocumentPDFBytes` + `formField` blocks. Input validation rejects radio/dropdown fields missing options.
+- **feat(tool): embed_image** — embed a JPEG or PNG image (base64-encoded) into a titled PDF document with optional caption and render dimensions. Magic-byte validation prevents mime type mismatch. pdfnative image errors are surfaced as actionable `ToolError` messages (e.g. alpha-channel PNGs not supported).
+- **feat(tool): prepare_signature_placeholder** — create a PDF with an embedded `/Sig` placeholder (AcroForm + Widget annotation) ready for `sign_pdf`. Accepts optional signer metadata (`signerName`, `reason`, `location`, `contactInfo`) and optional body blocks. The `/ByteRange` and `/Contents` placeholders comply exactly with the structure expected by pdfnative's `signPdfBytes`.
+- **feat(transport): HTTP mode** — `cli.ts` now supports `PDFNATIVE_MCP_PORT` environment variable. When set, the server starts a `StreamableHTTPServerTransport` on `http://127.0.0.1:<port>/mcp` (POST/GET/DELETE). Falls back to stdio when the variable is absent or invalid.
+
+## Changed
+
+- **chore(server):** `SERVER_VERSION` bumped to `0.2.0`.
+- **chore(server):** `SERVER_INSTRUCTIONS` updated to document all 8 tools.
+- **chore(package):** `package.json` `description` updated to reflect full tool surface.
+
+## Install
+
+```
+npm install pdfnative-mcp@0.2.0
+```
+
+## Upgrade
+
+No breaking changes. Drop-in replacement for v0.1.0.
+
+All v0.1.0 tool names and schemas are unchanged. The only observable difference is that `tools/list` now returns 8 tools instead of 4.
+
+## Links
+
+- CHANGELOG: ../CHANGELOG.md
+- Full diff: https://github.com/Nizoka/pdfnative-mcp/compare/v0.1.0...v0.2.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 /**
- * CLI entry — wires the MCP server to a stdio transport. Designed to be spawned
- * by an MCP-compatible host (Claude Desktop, Cursor, Continue, etc.).
+ * CLI entry — wires the MCP server to a stdio transport (default) or a
+ * Streamable HTTP transport when PDFNATIVE_MCP_PORT is set.
  *
- * @example Claude Desktop config
+ * Transport selection:
+ *   - stdio (default): suitable for local host integration (Claude Desktop, Cursor, etc.)
+ *   - HTTP: set PDFNATIVE_MCP_PORT=<port> to expose the MCP endpoint on that port.
+ *           Requests must be POST to /mcp. Useful for remote or containerised deployments.
+ *
+ * @example Claude Desktop config (stdio)
  * ```json
  * {
  *   "mcpServers": {
@@ -15,30 +20,84 @@
  *   }
  * }
  * ```
+ *
+ * @example HTTP mode
+ * ```bash
+ * PDFNATIVE_MCP_PORT=3000 npx pdfnative-mcp
+ * # Then connect via: http://localhost:3000/mcp
+ * ```
  */
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { createServer, ensureCompressionReady } from './server.js';
 
 async function main(): Promise<void> {
     await ensureCompressionReady();
 
     const server = createServer();
-    const transport = new StdioServerTransport();
+    const portEnv = process.env['PDFNATIVE_MCP_PORT'];
+    const port = portEnv !== undefined ? parseInt(portEnv, 10) : NaN;
 
-    const shutdown = async (signal: string): Promise<void> => {
-        process.stderr.write(`\n[pdfnative-mcp] received ${signal}, shutting down...\n`);
-        try {
-            await server.close();
-        } finally {
-            process.exit(0);
-        }
-    };
+    if (!Number.isNaN(port) && port > 0 && port < 65536) {
+        // --- HTTP / Streamable HTTP transport ---
+        const { StreamableHTTPServerTransport } = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
+        const { createServer: createHttpServer } = await import('node:http');
 
-    process.on('SIGINT', () => void shutdown('SIGINT'));
-    process.on('SIGTERM', () => void shutdown('SIGTERM'));
+        const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
 
-    await server.connect(transport);
-    process.stderr.write('[pdfnative-mcp] ready (stdio transport)\n');
+        const shutdown = async (signal: string): Promise<void> => {
+            process.stderr.write(`\n[pdfnative-mcp] received ${signal}, shutting down...\n`);
+            try {
+                await server.close();
+            } finally {
+                process.exit(0);
+            }
+        };
+
+        process.on('SIGINT', () => void shutdown('SIGINT'));
+        process.on('SIGTERM', () => void shutdown('SIGTERM'));
+
+        const httpServer = createHttpServer(async (req, res) => {
+            if (req.url === '/mcp' && req.method === 'POST') {
+                await transport.handleRequest(req, res);
+            } else if (req.url === '/mcp' && req.method === 'GET') {
+                await transport.handleRequest(req, res);
+            } else if (req.url === '/mcp' && req.method === 'DELETE') {
+                await transport.handleRequest(req, res);
+            } else {
+                res.writeHead(404, { 'Content-Type': 'text/plain' });
+                res.end('Not Found. MCP endpoint is POST /mcp');
+            }
+        });
+
+        await server.connect(transport);
+
+        await new Promise<void>((resolve, reject) => {
+            httpServer.listen(port, '127.0.0.1', () => {
+                process.stderr.write(`[pdfnative-mcp] ready (HTTP transport) on http://127.0.0.1:${port}/mcp\n`);
+                resolve();
+            });
+            httpServer.once('error', reject);
+        });
+    } else {
+        // --- stdio transport (default) ---
+        const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
+
+        const transport = new StdioServerTransport();
+
+        const shutdown = async (signal: string): Promise<void> => {
+            process.stderr.write(`\n[pdfnative-mcp] received ${signal}, shutting down...\n`);
+            try {
+                await server.close();
+            } finally {
+                process.exit(0);
+            }
+        };
+
+        process.on('SIGINT', () => void shutdown('SIGINT'));
+        process.on('SIGTERM', () => void shutdown('SIGTERM'));
+
+        await server.connect(transport);
+        process.stderr.write('[pdfnative-mcp] ready (stdio transport)\n');
+    }
 }
 
 main().catch((err: unknown) => {
@@ -46,3 +105,4 @@ main().catch((err: unknown) => {
     process.stderr.write(`[pdfnative-mcp] fatal: ${message}\n`);
     process.exit(1);
 });
+

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,10 +34,30 @@ import {
     ADD_INTERNATIONAL_TEXT_INPUT_SCHEMA,
     addInternationalText,
 } from './tools/add-international-text.js';
+import {
+    ADD_TABLE_NAME,
+    ADD_TABLE_INPUT_SCHEMA,
+    addTable,
+} from './tools/add-table.js';
+import {
+    ADD_FORM_NAME,
+    ADD_FORM_INPUT_SCHEMA,
+    addForm,
+} from './tools/add-form.js';
+import {
+    EMBED_IMAGE_NAME,
+    EMBED_IMAGE_INPUT_SCHEMA,
+    embedImage,
+} from './tools/embed-image.js';
+import {
+    PREPARE_SIGNATURE_PLACEHOLDER_NAME,
+    PREPARE_SIGNATURE_PLACEHOLDER_INPUT_SCHEMA,
+    prepareSignaturePlaceholder,
+} from './tools/prepare-signature-placeholder.js';
 
 // JSON import attribute (Node 22+, TS 5.3+) keeps version in lock-step with package.json.
 // Hardcoded here to keep the build rootDir limited to ./src; tests assert it stays in sync.
-const SERVER_VERSION = '0.1.0';
+const SERVER_VERSION = '0.2.0';
 const SERVER_NAME = 'pdfnative-mcp';
 
 
@@ -92,16 +112,56 @@ const TOOLS: readonly ToolDefinition[] = [
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         handler: addInternationalText,
     },
+    {
+        name: ADD_TABLE_NAME,
+        title: 'Add table / report',
+        description:
+            'Generate a tabular PDF report from column headers and data rows. Ideal for data exports, financial summaries, schedules, and any content that fits naturally into rows and columns.',
+        inputSchema: ADD_TABLE_INPUT_SCHEMA,
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        handler: addTable,
+    },
+    {
+        name: ADD_FORM_NAME,
+        title: 'Add interactive form',
+        description:
+            'Generate a PDF containing an interactive AcroForm with text fields, text areas, checkboxes, radio buttons, and dropdowns. Suitable for data-capture forms, surveys, and fillable templates.',
+        inputSchema: ADD_FORM_INPUT_SCHEMA,
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        handler: addForm,
+    },
+    {
+        name: EMBED_IMAGE_NAME,
+        title: 'Embed image in PDF',
+        description:
+            'Generate a PDF document with an embedded JPEG or PNG image. The image is accepted as a base64-encoded string and can include an optional caption and custom render dimensions.',
+        inputSchema: EMBED_IMAGE_INPUT_SCHEMA,
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        handler: embedImage,
+    },
+    {
+        name: PREPARE_SIGNATURE_PLACEHOLDER_NAME,
+        title: 'Prepare signature placeholder',
+        description:
+            "Create a PDF with an embedded /Sig AcroForm placeholder ready to be digitally signed by the sign_pdf tool. Optionally accepts document body blocks and signer metadata (name, reason, location). Use this as step 1 of a two-step sign workflow: prepare → sign.",
+        inputSchema: PREPARE_SIGNATURE_PLACEHOLDER_INPUT_SCHEMA,
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        handler: prepareSignaturePlaceholder,
+    },
 ];
 
 const TOOL_INDEX: ReadonlyMap<string, ToolDefinition> = new Map(TOOLS.map((t) => [t.name, t]));
 
 const SERVER_INSTRUCTIONS = `pdfnative-mcp bridges the zero-dependency 'pdfnative' library to MCP.
 Available tools:
-  • ${GENERATE_BASIC_PDF_NAME} — multi-page documents from structured blocks (preferred for reports, letters, manuals).
+  • ${GENERATE_BASIC_PDF_NAME} — multi-page documents from structured blocks (headings, paragraphs, lists).
   • ${ADD_BARCODE_NAME} — barcodes / QR codes (tickets, labels, vouchers).
   • ${ADD_INTERNATIONAL_TEXT_NAME} — non-Latin scripts via embedded Noto fonts (BiDi + shaping handled).
   • ${SIGN_PDF_NAME} — apply a CMS signature to a PDF that already has a /Sig placeholder.
+  • ${ADD_TABLE_NAME} — tabular PDF reports from headers + data rows.
+  • ${ADD_FORM_NAME} — interactive AcroForm PDFs (text fields, checkboxes, dropdowns).
+  • ${EMBED_IMAGE_NAME} — embed a JPEG or PNG image into a PDF document.
+  • ${PREPARE_SIGNATURE_PLACEHOLDER_NAME} — create a PDF with a /Sig placeholder ready for sign_pdf (step 1 of two-step signing).
 Output is always returned as base64 unless the host has set the PDFNATIVE_MPC_OUTPUT_DIR env var, in which case outputMode='file' writes to a sandboxed path.`;
 
 function buildSuccessResult(output: OutputResult, toolName: string): CallToolResult {

--- a/src/tools/add-form.ts
+++ b/src/tools/add-form.ts
@@ -1,0 +1,183 @@
+/**
+ * Tool: add_form
+ *
+ * Generates a PDF containing an interactive form with text fields, text areas,
+ * checkboxes, radio buttons, and dropdowns using pdfnative's document builder.
+ * Suitable for data-capture forms, surveys, and fillable templates.
+ */
+import { buildDocumentPDFBytes, type DocumentBlock } from 'pdfnative';
+import { z } from 'zod';
+import { emitPdf, type OutputResult } from '../output.js';
+import { ToolError } from '../errors.js';
+
+export const ADD_FORM_NAME = 'add_form';
+
+const FORM_FIELD_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['fieldType', 'name'],
+    properties: {
+        fieldType: {
+            type: 'string',
+            enum: ['text', 'textarea', 'checkbox', 'radio', 'dropdown'],
+            description: 'Type of form control to render.',
+        },
+        name: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 100,
+            description: 'Unique field name used as the PDF annotation identifier.',
+        },
+        label: {
+            type: 'string',
+            maxLength: 200,
+            description: 'Human-readable label shown above the field.',
+        },
+        value: {
+            type: 'string',
+            maxLength: 2000,
+            description: 'Default value pre-filled in the field.',
+        },
+        options: {
+            type: 'array',
+            description: 'Choices for dropdown or radio fields.',
+            maxItems: 100,
+            items: { type: 'string', maxLength: 200 },
+        },
+        readOnly: { type: 'boolean', description: 'Prevent editing of this field.' },
+        required: { type: 'boolean', description: 'Mark field as required.' },
+        maxLength: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 32767,
+            description: 'Maximum character length for text/textarea fields.',
+        },
+        width: {
+            type: 'number',
+            minimum: 10,
+            maximum: 500,
+            description: 'Field width in points (optional).',
+        },
+        height: {
+            type: 'number',
+            minimum: 10,
+            maximum: 300,
+            description: 'Field height in points (optional).',
+        },
+        checked: {
+            type: 'boolean',
+            description: 'Initial checked state for checkbox fields.',
+        },
+        fontSize: {
+            type: 'number',
+            minimum: 6,
+            maximum: 48,
+            description: 'Font size for text rendering inside the field.',
+        },
+    },
+};
+
+export const ADD_FORM_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+        title: {
+            type: 'string',
+            description: 'Form title rendered at the top of the document.',
+            minLength: 1,
+            maxLength: 200,
+        },
+        fields: {
+            type: 'array',
+            description: 'Ordered list of form field definitions.',
+            minItems: 1,
+            maxItems: 200,
+            items: FORM_FIELD_SCHEMA,
+        },
+        footerText: {
+            type: 'string',
+            maxLength: 200,
+            description: 'Optional footer text rendered at the bottom of every page.',
+        },
+        outputMode: {
+            type: 'string',
+            enum: ['base64', 'file'],
+            default: 'base64',
+            description:
+                "Either 'base64' (returns the PDF inline) or 'file' (writes to a sandboxed path inside PDFNATIVE_MPC_OUTPUT_DIR).",
+        },
+        outputPath: {
+            type: 'string',
+            description: "Required when outputMode='file'. Relative path inside the sandbox; must end with .pdf.",
+        },
+    },
+    required: ['title', 'fields'],
+} as const;
+
+const FieldSchema = z.object({
+    fieldType: z.enum(['text', 'textarea', 'checkbox', 'radio', 'dropdown']),
+    name: z.string().min(1).max(100),
+    label: z.string().max(200).optional(),
+    value: z.string().max(2000).optional(),
+    options: z.array(z.string().max(200)).max(100).optional(),
+    readOnly: z.boolean().optional(),
+    required: z.boolean().optional(),
+    maxLength: z.number().int().min(1).max(32767).optional(),
+    width: z.number().min(10).max(500).optional(),
+    height: z.number().min(10).max(300).optional(),
+    checked: z.boolean().optional(),
+    fontSize: z.number().min(6).max(48).optional(),
+});
+
+const InputSchema = z.object({
+    title: z.string().min(1).max(200),
+    fields: z.array(FieldSchema).min(1).max(200),
+    footerText: z.string().max(200).optional(),
+    outputMode: z.enum(['base64', 'file']).default('base64'),
+    outputPath: z.string().optional(),
+});
+
+export async function addForm(rawInput: unknown): Promise<OutputResult> {
+    const parsed = InputSchema.safeParse(rawInput);
+    if (!parsed.success) {
+        throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
+    }
+    const { title, fields, footerText, outputMode, outputPath } = parsed.data;
+
+    // Validate that radio/dropdown fields have options
+    for (const field of fields) {
+        if ((field.fieldType === 'radio' || field.fieldType === 'dropdown') && (!field.options || field.options.length === 0)) {
+            throw new ToolError(
+                'VALIDATION_ERROR',
+                `Field '${field.name}' of type '${field.fieldType}' requires at least one option.`,
+            );
+        }
+    }
+
+    // Build blocks: title block + form fields
+    const blocks: DocumentBlock[] = fields.map(
+        (field): DocumentBlock => ({
+            type: 'formField',
+            fieldType: field.fieldType as 'text' | 'multilineText' | 'checkbox' | 'radio' | 'dropdown' | 'listbox',
+            name: field.name,
+            ...(field.label !== undefined ? { label: field.label } : {}),
+            ...(field.value !== undefined ? { value: field.value } : {}),
+            ...(field.options !== undefined ? { options: field.options } : {}),
+            ...(field.readOnly !== undefined ? { readOnly: field.readOnly } : {}),
+            ...(field.required !== undefined ? { required: field.required } : {}),
+            ...(field.maxLength !== undefined ? { maxLength: field.maxLength } : {}),
+            ...(field.width !== undefined ? { width: field.width } : {}),
+            ...(field.height !== undefined ? { height: field.height } : {}),
+            ...(field.checked !== undefined ? { checked: field.checked } : {}),
+            ...(field.fontSize !== undefined ? { fontSize: field.fontSize } : {}),
+        }),
+    );
+
+    const bytes = buildDocumentPDFBytes({
+        title,
+        blocks,
+        ...(footerText !== undefined ? { footerText } : {}),
+    });
+
+    return emitPdf(bytes, { mode: outputMode, ...(outputPath !== undefined ? { outputPath } : {}) });
+}

--- a/src/tools/add-table.ts
+++ b/src/tools/add-table.ts
@@ -1,0 +1,124 @@
+/**
+ * Tool: add_table
+ *
+ * Generates a tabular PDF report from a title, column headers, and data rows
+ * using pdfnative's table/report builder. Ideal for data exports, financial
+ * summaries, schedules, and any content that fits naturally into rows and columns.
+ */
+import { buildPDFBytes } from 'pdfnative';
+import { z } from 'zod';
+import { emitPdf, type OutputResult } from '../output.js';
+import { ToolError } from '../errors.js';
+
+export const ADD_TABLE_NAME = 'add_table';
+
+export const ADD_TABLE_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+        title: {
+            type: 'string',
+            description: 'Report title rendered at the top of the document and used as PDF metadata title.',
+            minLength: 1,
+            maxLength: 200,
+        },
+        headers: {
+            type: 'array',
+            description: 'Column header labels. Must have the same length as each row in `rows`.',
+            minItems: 1,
+            maxItems: 50,
+            items: { type: 'string', minLength: 1, maxLength: 200 },
+        },
+        rows: {
+            type: 'array',
+            description: 'Data rows. Each row is an array of cell strings with the same length as `headers`.',
+            minItems: 1,
+            maxItems: 5000,
+            items: {
+                type: 'array',
+                minItems: 1,
+                maxItems: 50,
+                items: { type: 'string', maxLength: 500 },
+            },
+        },
+        infoItems: {
+            type: 'array',
+            description: 'Optional key-value metadata rows rendered below the title (e.g. date, author).',
+            maxItems: 20,
+            items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['label', 'value'],
+                properties: {
+                    label: { type: 'string', minLength: 1, maxLength: 100 },
+                    value: { type: 'string', maxLength: 500 },
+                },
+            },
+        },
+        footerText: {
+            type: 'string',
+            maxLength: 200,
+            description: 'Optional text rendered at the bottom of every page.',
+        },
+        outputMode: {
+            type: 'string',
+            enum: ['base64', 'file'],
+            default: 'base64',
+            description:
+                "Either 'base64' (returns the PDF inline) or 'file' (writes to a sandboxed path inside PDFNATIVE_MPC_OUTPUT_DIR).",
+        },
+        outputPath: {
+            type: 'string',
+            description: "Required when outputMode='file'. Relative path inside the sandbox; must end with .pdf.",
+        },
+    },
+    required: ['title', 'headers', 'rows'],
+} as const;
+
+const InputSchema = z.object({
+    title: z.string().min(1).max(200),
+    headers: z.array(z.string().min(1).max(200)).min(1).max(50),
+    rows: z.array(z.array(z.string().max(500)).min(1).max(50)).min(1).max(5000),
+    infoItems: z
+        .array(
+            z.object({
+                label: z.string().min(1).max(100),
+                value: z.string().max(500),
+            }),
+        )
+        .max(20)
+        .optional(),
+    footerText: z.string().max(200).optional(),
+    outputMode: z.enum(['base64', 'file']).default('base64'),
+    outputPath: z.string().optional(),
+});
+
+export async function addTable(rawInput: unknown): Promise<OutputResult> {
+    const parsed = InputSchema.safeParse(rawInput);
+    if (!parsed.success) {
+        throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
+    }
+    const { title, headers, rows, infoItems, footerText, outputMode, outputPath } = parsed.data;
+
+    // Validate column count consistency: every row must have the same length as headers
+    for (let i = 0; i < rows.length; i++) {
+        if (rows[i].length !== headers.length) {
+            throw new ToolError(
+                'VALIDATION_ERROR',
+                `Row ${i} has ${rows[i].length} cell(s) but headers defines ${headers.length} column(s).`,
+            );
+        }
+    }
+
+    const bytes = buildPDFBytes({
+        title,
+        infoItems: (infoItems ?? []).map((item) => ({ label: item.label, value: item.value })),
+        balanceText: '',
+        countText: '',
+        headers,
+        rows: rows.map((cells) => ({ cells, type: '', pointed: false })),
+        footerText: footerText ?? '',
+    });
+
+    return emitPdf(bytes, { mode: outputMode, ...(outputPath !== undefined ? { outputPath } : {}) });
+}

--- a/src/tools/embed-image.ts
+++ b/src/tools/embed-image.ts
@@ -1,0 +1,140 @@
+/**
+ * Tool: embed_image
+ *
+ * Generates a PDF document with an embedded image (JPEG or PNG) using
+ * pdfnative's document builder. The image is accepted as a base64-encoded
+ * string and can optionally be wrapped in a titled document with a caption.
+ */
+import { buildDocumentPDFBytes } from 'pdfnative';
+import { z } from 'zod';
+import { emitPdf, type OutputResult } from '../output.js';
+import { ToolError } from '../errors.js';
+
+export const EMBED_IMAGE_NAME = 'embed_image';
+
+export const EMBED_IMAGE_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+        title: {
+            type: 'string',
+            description: 'Document title rendered at the top and used as PDF metadata title.',
+            minLength: 1,
+            maxLength: 200,
+        },
+        imageBase64: {
+            type: 'string',
+            description: 'Base64-encoded image bytes. Supports JPEG and PNG formats.',
+            minLength: 4,
+        },
+        mimeType: {
+            type: 'string',
+            enum: ['image/jpeg', 'image/png'],
+            description: 'MIME type of the image. Must match the actual encoding of imageBase64.',
+        },
+        caption: {
+            type: 'string',
+            maxLength: 500,
+            description: 'Optional caption rendered below the image.',
+        },
+        width: {
+            type: 'number',
+            minimum: 10,
+            maximum: 800,
+            description: 'Render width in points. If omitted, the image is auto-sized to fit the page.',
+        },
+        height: {
+            type: 'number',
+            minimum: 10,
+            maximum: 1000,
+            description: 'Render height in points. If omitted, aspect ratio is preserved.',
+        },
+        outputMode: {
+            type: 'string',
+            enum: ['base64', 'file'],
+            default: 'base64',
+            description:
+                "Either 'base64' (returns the PDF inline) or 'file' (writes to a sandboxed path inside PDFNATIVE_MPC_OUTPUT_DIR).",
+        },
+        outputPath: {
+            type: 'string',
+            description: "Required when outputMode='file'. Relative path inside the sandbox; must end with .pdf.",
+        },
+    },
+    required: ['title', 'imageBase64', 'mimeType'],
+} as const;
+
+const InputSchema = z.object({
+    title: z.string().min(1).max(200),
+    imageBase64: z.string().min(4),
+    mimeType: z.enum(['image/jpeg', 'image/png']),
+    caption: z.string().max(500).optional(),
+    width: z.number().min(10).max(800).optional(),
+    height: z.number().min(10).max(1000).optional(),
+    outputMode: z.enum(['base64', 'file']).default('base64'),
+    outputPath: z.string().optional(),
+});
+
+export async function embedImage(rawInput: unknown): Promise<OutputResult> {
+    const parsed = InputSchema.safeParse(rawInput);
+    if (!parsed.success) {
+        throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
+    }
+    const { title, imageBase64, mimeType, caption, width, height, outputMode, outputPath } = parsed.data;
+
+    // Decode base64 to raw bytes
+    let imageBytes: Uint8Array;
+    try {
+        const buf = Buffer.from(imageBase64, 'base64');
+        // Validate the decoded length is non-trivial (base64 of valid image)
+        if (buf.length < 8) {
+            throw new Error('Decoded image is too small to be a valid JPEG or PNG.');
+        }
+        imageBytes = new Uint8Array(buf);
+    } catch (err) {
+        throw new ToolError(
+            'VALIDATION_ERROR',
+            `Failed to decode imageBase64: ${err instanceof Error ? err.message : String(err)}`,
+        );
+    }
+
+    // Validate magic bytes match mimeType
+    if (mimeType === 'image/jpeg') {
+        if (imageBytes[0] !== 0xff || imageBytes[1] !== 0xd8) {
+            throw new ToolError('VALIDATION_ERROR', "Image bytes do not match mimeType 'image/jpeg' (missing JPEG magic bytes FF D8).");
+        }
+    } else {
+        // PNG: magic is 89 50 4E 47 0D 0A 1A 0A
+        if (
+            imageBytes[0] !== 0x89 ||
+            imageBytes[1] !== 0x50 ||
+            imageBytes[2] !== 0x4e ||
+            imageBytes[3] !== 0x47
+        ) {
+            throw new ToolError('VALIDATION_ERROR', "Image bytes do not match mimeType 'image/png' (missing PNG magic bytes 89 50 4E 47).");
+        }
+    }
+
+    let bytes: Uint8Array;
+    try {
+        bytes = buildDocumentPDFBytes({
+            title,
+            blocks: [
+                {
+                    type: 'image',
+                    data: imageBytes,
+                    ...(width !== undefined ? { width } : {}),
+                    ...(height !== undefined ? { height } : {}),
+                },
+                ...(caption !== undefined
+                    ? [{ type: 'paragraph' as const, text: caption }]
+                    : []),
+            ],
+        });
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new ToolError('VALIDATION_ERROR', `Failed to embed image: ${msg}`);
+    }
+
+    return emitPdf(bytes, { mode: outputMode, ...(outputPath !== undefined ? { outputPath } : {}) });
+}

--- a/src/tools/prepare-signature-placeholder.ts
+++ b/src/tools/prepare-signature-placeholder.ts
@@ -1,0 +1,353 @@
+/**
+ * Tool: prepare_signature_placeholder
+ *
+ * Creates a PDF document with an embedded /Sig placeholder (AcroForm + Widget annotation)
+ * that is ready to be signed with the `sign_pdf` tool. The produced PDF conforms to the
+ * PAdES structure expected by pdfnative's signPdfBytes function.
+ *
+ * Workflow:
+ *   1. Call prepare_signature_placeholder → outputs a .pdf with /Contents and /ByteRange placeholders
+ *   2. Pass that PDF to sign_pdf together with a certificate and private key → signed PDF
+ */
+import { buildDocumentPDFBytes, openPdf, findStartxref, isRef, isName, isArray, isDict, isStream, type PdfValue, type PdfRef, type DocumentBlock } from 'pdfnative';
+import { z } from 'zod';
+import { emitPdf, type OutputResult } from '../output.js';
+import { ToolError } from '../errors.js';
+
+export const PREPARE_SIGNATURE_PLACEHOLDER_NAME = 'prepare_signature_placeholder';
+
+export const PREPARE_SIGNATURE_PLACEHOLDER_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+        title: {
+            type: 'string',
+            description: 'Document title. Used as the PDF metadata title and rendered at the top of page 1.',
+            minLength: 1,
+            maxLength: 200,
+        },
+        signerName: {
+            type: 'string',
+            maxLength: 200,
+            description: 'Name of the intended signer, embedded in the /Sig dictionary.',
+        },
+        reason: {
+            type: 'string',
+            maxLength: 500,
+            description: 'Reason for signing (e.g. "Approved", "I agree to the terms").',
+        },
+        location: {
+            type: 'string',
+            maxLength: 200,
+            description: 'Signing location (city / country).',
+        },
+        contactInfo: {
+            type: 'string',
+            maxLength: 200,
+            description: 'Contact information for the signer.',
+        },
+        blocks: {
+            type: 'array',
+            description: 'Optional document body blocks rendered before the signature field.',
+            maxItems: 2000,
+            items: {
+                oneOf: [
+                    {
+                        type: 'object',
+                        additionalProperties: false,
+                        required: ['type', 'text', 'level'],
+                        properties: {
+                            type: { const: 'heading' },
+                            text: { type: 'string', minLength: 1, maxLength: 500 },
+                            level: { type: 'integer', enum: [1, 2, 3] },
+                        },
+                    },
+                    {
+                        type: 'object',
+                        additionalProperties: false,
+                        required: ['type', 'text'],
+                        properties: {
+                            type: { const: 'paragraph' },
+                            text: { type: 'string', minLength: 1, maxLength: 50000 },
+                        },
+                    },
+                    {
+                        type: 'object',
+                        additionalProperties: false,
+                        required: ['type'],
+                        properties: {
+                            type: { const: 'pageBreak' },
+                        },
+                    },
+                    {
+                        type: 'object',
+                        additionalProperties: false,
+                        required: ['type', 'height'],
+                        properties: {
+                            type: { const: 'spacer' },
+                            height: { type: 'number', minimum: 1, maximum: 500 },
+                        },
+                    },
+                ],
+            },
+        },
+        outputMode: {
+            type: 'string',
+            enum: ['base64', 'file'],
+            default: 'base64',
+            description:
+                "Either 'base64' (returns the PDF inline) or 'file' (writes to a sandboxed path inside PDFNATIVE_MPC_OUTPUT_DIR).",
+        },
+        outputPath: {
+            type: 'string',
+            description: "Required when outputMode='file'. Relative path inside the sandbox; must end with .pdf.",
+        },
+    },
+    required: ['title'],
+} as const;
+
+const BlockSchema = z.discriminatedUnion('type', [
+    z.object({ type: z.literal('heading'), text: z.string().min(1).max(500), level: z.union([z.literal(1), z.literal(2), z.literal(3)]) }),
+    z.object({ type: z.literal('paragraph'), text: z.string().min(1).max(50000) }),
+    z.object({ type: z.literal('pageBreak') }),
+    z.object({ type: z.literal('spacer'), height: z.number().min(1).max(500) }),
+]);
+
+const InputSchema = z.object({
+    title: z.string().min(1).max(200),
+    signerName: z.string().max(200).optional(),
+    reason: z.string().max(500).optional(),
+    location: z.string().max(200).optional(),
+    contactInfo: z.string().max(200).optional(),
+    blocks: z.array(BlockSchema).max(2000).optional(),
+    outputMode: z.enum(['base64', 'file']).default('base64'),
+    outputPath: z.string().optional(),
+});
+
+/** Escape a PDF string literal (parenthesis form). */
+function escapePdfLiteral(s: string): string {
+    return s.replace(/[\\()]/g, (c) => '\\' + c);
+}
+
+/** Format a date in PDF date string format D:YYYYMMDDHHmmssZ. */
+function pdfDateString(d: Date): string {
+    const p = (n: number): string => String(n).padStart(2, '0');
+    return `D:${d.getUTCFullYear()}${p(d.getUTCMonth() + 1)}${p(d.getUTCDate())}${p(d.getUTCHours())}${p(d.getUTCMinutes())}${p(d.getUTCSeconds())}Z`;
+}
+
+/** Build a raw /Sig dictionary string with a zeroed /Contents placeholder and /ByteRange placeholder. */
+function buildSigDictRaw(opts: {
+    name?: string;
+    reason?: string;
+    location?: string;
+    contactInfo?: string;
+}): string {
+    const DEFAULT_CONTENTS_SIZE = 16384;
+    const BYTERANGE_PLACEHOLDER = '/ByteRange [0 0000000000 0000000000 0000000000]';
+    const hexLen = DEFAULT_CONTENTS_SIZE * 2;
+    const parts: string[] = [
+        '<< /Type /Sig',
+        '/Filter /Adobe.PPKLite',
+        '/SubFilter /adbe.pkcs7.detached',
+        `/Contents <${'0'.repeat(hexLen)}>`,
+        BYTERANGE_PLACEHOLDER,
+    ];
+    if (opts.name) parts.push(`/Name (${escapePdfLiteral(opts.name)})`);
+    if (opts.reason) parts.push(`/Reason (${escapePdfLiteral(opts.reason)})`);
+    if (opts.location) parts.push(`/Location (${escapePdfLiteral(opts.location)})`);
+    if (opts.contactInfo) parts.push(`/ContactInfo (${escapePdfLiteral(opts.contactInfo)})`);
+    parts.push(`/M (${pdfDateString(new Date())})`);
+    parts.push('>>');
+    return parts.join('\n');
+}
+
+/**
+ * Minimal PDF value serializer for reconstructing modified catalog/page objects.
+ * Handles all PdfValue variants that appear in standard document structures.
+ */
+function serializePdfValue(val: PdfValue): string {
+    if (val === null) return 'null';
+    if (typeof val === 'boolean') return val ? 'true' : 'false';
+    if (typeof val === 'number') {
+        return Number.isInteger(val) ? String(val) : val.toFixed(4).replace(/\.?0+$/, '');
+    }
+    if (typeof val === 'string') {
+        return `(${val.replace(/[\\()]/g, (c) => '\\' + c)})`;
+    }
+    if (isName(val)) return `/${val.value}`;
+    if (isRef(val)) return `${val.num} ${val.gen} R`;
+    if (isArray(val)) return `[${val.map(serializePdfValue).join(' ')}]`;
+    if (isDict(val)) {
+        let s = '<<';
+        for (const [k, v] of val) s += ` /${k} ${serializePdfValue(v)}`;
+        return s + ' >>';
+    }
+    if (isStream(val)) {
+        // Streams appear as dicts in context (used only for dict-level serialization)
+        let s = '<<';
+        for (const [k, v] of val.dict) s += ` /${k} ${serializePdfValue(v)}`;
+        return s + ' >>';
+    }
+    return 'null';
+}
+
+/**
+ * Build an incremental xref section string.
+ */
+function buildXref(entries: Map<number, number>): string {
+    const sorted = [...entries.keys()].sort((a, b) => a - b);
+    if (sorted.length === 0) return 'xref\n0 0\n';
+    let result = 'xref\n';
+    let i = 0;
+    while (i < sorted.length) {
+        const start = sorted[i];
+        let end = start;
+        while (i + 1 < sorted.length && sorted[i + 1] === end + 1) {
+            i++;
+            end = sorted[i];
+        }
+        const count = end - start + 1;
+        result += `${start} ${count}\n`;
+        for (let num = start; num <= end; num++) {
+            const off = entries.get(num) ?? 0;
+            result += `${String(off).padStart(10, '0')} 00000 n \n`;
+        }
+        i++;
+    }
+    return result;
+}
+
+export async function prepareSignaturePlaceholder(rawInput: unknown): Promise<OutputResult> {
+    const parsed = InputSchema.safeParse(rawInput);
+    if (!parsed.success) {
+        throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
+    }
+    const { title, signerName, reason, location, contactInfo, blocks, outputMode, outputPath } = parsed.data;
+
+    // --- Build base document ---
+    const contentBlocks: DocumentBlock[] = (blocks ?? []).map((b): DocumentBlock => {
+        switch (b.type) {
+            case 'heading': return { type: 'heading', text: b.text, level: b.level };
+            case 'paragraph': return { type: 'paragraph', text: b.text };
+            case 'pageBreak': return { type: 'pageBreak' };
+            case 'spacer': return { type: 'spacer', height: b.height };
+        }
+    });
+
+    // Always have at least one content block
+    if (contentBlocks.length === 0) {
+        contentBlocks.push({ type: 'paragraph', text: 'This document contains a digital signature field.' });
+    }
+
+    const baseBytes = buildDocumentPDFBytes({ title, blocks: contentBlocks });
+
+    // --- Parse structure ---
+    const reader = openPdf(baseBytes);
+    const trailer = reader.trailer;
+
+    const rootRef = trailer.get('Root') as PdfRef;
+    const catalogObjNum = rootRef.num;
+
+    // Navigate to first page object number
+    const catalog = reader.getCatalog();
+    const pagesTreeVal = reader.resolveValue(catalog.get('Pages') as PdfValue);
+    if (!isDict(pagesTreeVal)) {
+        throw new ToolError('INTERNAL_ERROR', 'Cannot locate /Pages tree in generated PDF.');
+    }
+    const kidsRaw = pagesTreeVal.get('Kids');
+    const kidsVal = kidsRaw !== undefined ? kidsRaw : null;
+    if (!isArray(kidsVal) || kidsVal.length === 0) {
+        throw new ToolError('INTERNAL_ERROR', 'Cannot locate page objects in generated PDF.');
+    }
+    const page0Ref = kidsVal[0] as PdfRef;
+    const pageObjNum = page0Ref.num;
+
+    const prevXrefOffset = findStartxref(baseBytes);
+    const trailerSize = trailer.get('Size') as number; // next available object number
+
+    // Allocate new object numbers
+    const sigObjNum = trailerSize;       // e.g. 8
+    const widgetObjNum = trailerSize + 1; // e.g. 9
+    const newTrailerSize = trailerSize + 2;
+
+    // --- Sig dict (raw PDF text) ---
+    const sigDictStr = buildSigDictRaw({
+        ...(signerName !== undefined ? { name: signerName } : {}),
+        ...(reason !== undefined ? { reason } : {}),
+        ...(location !== undefined ? { location } : {}),
+        ...(contactInfo !== undefined ? { contactInfo } : {}),
+    });
+
+    // --- Incremental update assembly ---
+    // Offsets are measured in bytes from the start of the file.
+    // All content here is ASCII/Latin-1 so string.length === byte length.
+    let baseOffset = baseBytes.length;
+    const xrefEntries = new Map<number, number>();
+    const parts: string[] = [];
+
+    // Separator newline between base PDF and incremental update
+    parts.push('\n');
+    baseOffset += 1;
+
+    // Object sigObjNum: the sig dict (raw embedded as indirect object)
+    const sigObjParts = [`${sigObjNum} 0 obj\n`, sigDictStr, '\nendobj\n\n'];
+    const sigObjStr = sigObjParts.join('');
+    xrefEntries.set(sigObjNum, baseOffset);
+    parts.push(sigObjStr);
+    baseOffset += sigObjStr.length;
+
+    // Object widgetObjNum: form widget annotation (invisible, type /Sig)
+    // F=132: Print(4) + Hidden(2) = 6, but for sig annotations use F=132 (Print=4, ReadOnly=64, Hidden bit off)
+    // Actually F=4 = Print only, invisible on screen is achieved via Rect [0 0 0 0]
+    const widgetStr = `${widgetObjNum} 0 obj\n<< /Type /Annot /Subtype /Widget /FT /Sig /Rect [0 0 0 0] /P ${pageObjNum} 0 R /T (Signature1) /V ${sigObjNum} 0 R /F 4 >>\nendobj\n\n`;
+    xrefEntries.set(widgetObjNum, baseOffset);
+    parts.push(widgetStr);
+    baseOffset += widgetStr.length;
+
+    // Updated catalog: add /AcroForm
+    const updatedCatalog = new Map(catalog);
+    const acroFormDict = new Map<string, PdfValue>();
+    acroFormDict.set('Fields', [{ type: 'ref' as const, num: widgetObjNum, gen: 0 }]);
+    acroFormDict.set('SigFlags', 3);
+    updatedCatalog.set('AcroForm', acroFormDict);
+    const catalogObjStr = `${catalogObjNum} 0 obj\n${serializePdfValue(updatedCatalog)}\nendobj\n\n`;
+    xrefEntries.set(catalogObjNum, baseOffset);
+    parts.push(catalogObjStr);
+    baseOffset += catalogObjStr.length;
+
+    // Updated page 0: add /Annots
+    const page0 = reader.getPage(0);
+    const updatedPage = new Map(page0);
+    updatedPage.set('Annots', [{ type: 'ref' as const, num: widgetObjNum, gen: 0 }]);
+    const pageObjStr = `${pageObjNum} 0 obj\n${serializePdfValue(updatedPage)}\nendobj\n\n`;
+    xrefEntries.set(pageObjNum, baseOffset);
+    parts.push(pageObjStr);
+    baseOffset += pageObjStr.length;
+
+    // Xref table
+    const xrefStr = buildXref(xrefEntries);
+    const xrefOffset = baseOffset;
+    parts.push(xrefStr);
+    baseOffset += xrefStr.length;
+
+    // Trailer
+    const trailerParts: string[] = [`trailer\n<< /Size ${newTrailerSize} /Root ${catalogObjNum} 0 R`];
+    const infoRef = trailer.get('Info');
+    if (infoRef !== undefined) trailerParts.push(` /Info ${serializePdfValue(infoRef as PdfValue)}`);
+    const idVal = trailer.get('ID');
+    if (idVal !== undefined) trailerParts.push(` /ID ${serializePdfValue(idVal as PdfValue)}`);
+    trailerParts.push(` /Prev ${prevXrefOffset} >>\n`);
+    const trailerStr = trailerParts.join('');
+    parts.push(trailerStr);
+
+    parts.push(`startxref\n${xrefOffset}\n%%EOF\n`);
+
+    // Combine base PDF bytes + incremental update
+    const updateStr = parts.join('');
+    const updateBytes = Buffer.from(updateStr, 'latin1');
+    const combined = new Uint8Array(baseBytes.length + updateBytes.length);
+    combined.set(baseBytes, 0);
+    combined.set(updateBytes, baseBytes.length);
+
+    return emitPdf(combined, { mode: outputMode, ...(outputPath !== undefined ? { outputPath } : {}) });
+}

--- a/tests/add-form.test.ts
+++ b/tests/add-form.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { addForm } from '../src/tools/add-form.js';
+import { ensureCompressionReady } from '../src/server.js';
+import { ToolError } from '../src/errors.js';
+
+beforeAll(async () => {
+    delete process.env['PDFNATIVE_MPC_OUTPUT_DIR'];
+    await ensureCompressionReady();
+});
+
+const PDF_HEADER = '%PDF-';
+
+function decode(b64: string): string {
+    return Buffer.from(b64, 'base64').toString('latin1').slice(0, 5);
+}
+
+describe('add_form', () => {
+    it('produces a valid PDF with a text field', async () => {
+        const result = await addForm({
+            title: 'Contact Form',
+            fields: [
+                { fieldType: 'text', name: 'firstName', label: 'First Name' },
+                { fieldType: 'text', name: 'lastName', label: 'Last Name', required: true },
+            ],
+        });
+        expect(result.mode).toBe('base64');
+        expect(result.sizeBytes).toBeGreaterThan(100);
+        expect(decode(result.base64!)).toBe(PDF_HEADER);
+    });
+
+    it('produces a PDF with all supported field types', async () => {
+        const result = await addForm({
+            title: 'Full Form',
+            fields: [
+                { fieldType: 'text', name: 'name', label: 'Name', value: 'Alice' },
+                { fieldType: 'textarea', name: 'bio', label: 'Biography', height: 80 },
+                { fieldType: 'checkbox', name: 'agree', label: 'I agree', checked: true },
+                { fieldType: 'radio', name: 'color', label: 'Favorite color', options: ['Red', 'Blue', 'Green'] },
+                { fieldType: 'dropdown', name: 'country', label: 'Country', options: ['France', 'Germany'] },
+            ],
+            footerText: 'Please fill all fields.',
+        });
+        expect(result.mode).toBe('base64');
+        expect(decode(result.base64!)).toBe(PDF_HEADER);
+    });
+
+    it('rejects radio field without options', async () => {
+        await expect(
+            addForm({
+                title: 'Form',
+                fields: [{ fieldType: 'radio', name: 'choice' }],
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('rejects dropdown field without options', async () => {
+        await expect(
+            addForm({
+                title: 'Form',
+                fields: [{ fieldType: 'dropdown', name: 'pick' }],
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('rejects empty fields array', async () => {
+        await expect(
+            addForm({
+                title: 'Form',
+                fields: [],
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('rejects missing title', async () => {
+        await expect(
+            addForm({
+                fields: [{ fieldType: 'text', name: 'x' }],
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+});

--- a/tests/add-table.test.ts
+++ b/tests/add-table.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { addTable } from '../src/tools/add-table.js';
+import { ensureCompressionReady } from '../src/server.js';
+import { ToolError } from '../src/errors.js';
+
+beforeAll(async () => {
+    delete process.env['PDFNATIVE_MPC_OUTPUT_DIR'];
+    await ensureCompressionReady();
+});
+
+const PDF_HEADER = '%PDF-';
+
+function decode(b64: string): string {
+    return Buffer.from(b64, 'base64').toString('latin1').slice(0, 5);
+}
+
+describe('add_table', () => {
+    it('produces a valid PDF from minimal table data', async () => {
+        const result = await addTable({
+            title: 'Sales Report',
+            headers: ['Product', 'Units', 'Revenue'],
+            rows: [
+                ['Widget A', '100', '$1,000'],
+                ['Widget B', '200', '$2,500'],
+            ],
+        });
+        expect(result.mode).toBe('base64');
+        expect(result.sizeBytes).toBeGreaterThan(100);
+        expect(decode(result.base64!)).toBe(PDF_HEADER);
+    });
+
+    it('includes infoItems and footerText', async () => {
+        const result = await addTable({
+            title: 'Inventory',
+            headers: ['Item', 'Qty'],
+            rows: [['Pen', '50']],
+            infoItems: [
+                { label: 'Date', value: '2025-01-01' },
+                { label: 'Author', value: 'Alice' },
+            ],
+            footerText: 'Confidential',
+        });
+        expect(result.mode).toBe('base64');
+        expect(decode(result.base64!)).toBe(PDF_HEADER);
+    });
+
+    it('rejects mismatched row length', async () => {
+        await expect(
+            addTable({
+                title: 'Report',
+                headers: ['A', 'B', 'C'],
+                rows: [['x', 'y']], // only 2 cells, but 3 headers
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('rejects empty headers', async () => {
+        await expect(
+            addTable({
+                title: 'Report',
+                headers: [],
+                rows: [['x']],
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('rejects empty rows', async () => {
+        await expect(
+            addTable({
+                title: 'Report',
+                headers: ['Col'],
+                rows: [],
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('rejects missing required fields', async () => {
+        await expect(addTable({ title: 'Report' })).rejects.toThrow(ToolError);
+        await expect(addTable({})).rejects.toThrow(ToolError);
+    });
+});

--- a/tests/embed-image.test.ts
+++ b/tests/embed-image.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { embedImage } from '../src/tools/embed-image.js';
+import { ensureCompressionReady } from '../src/server.js';
+import { ToolError } from '../src/errors.js';
+
+beforeAll(async () => {
+    delete process.env['PDFNATIVE_MPC_OUTPUT_DIR'];
+    await ensureCompressionReady();
+});
+
+const PDF_HEADER = '%PDF-';
+
+function decode(b64: string): string {
+    return Buffer.from(b64, 'base64').toString('latin1').slice(0, 5);
+}
+
+/**
+ * Minimal valid 1×1 white JPEG (generated offline, embedded as base64).
+ * Magic bytes: FF D8 FF E0 ...
+ */
+const MINIMAL_JPEG_BASE64 =
+    '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/wAARC' +
+    'AABAAEDASIA/8QAFAABAAAAAAAAAAAAAAAAAAAACf/EABQQAQAAAAAAAAAAAAAAAAAAAAD/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/a' +
+    'AAwDAQACEQMRAD8AJQAB/9k=';
+
+/**
+ * Minimal valid 1×1 red PNG.
+ * Magic bytes: 89 50 4E 47 0D 0A 1A 0A
+ */
+const MINIMAL_PNG_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==';
+
+describe('embed_image', () => {
+    it('embeds a JPEG image and produces a valid PDF', async () => {
+        const result = await embedImage({
+            title: 'Photo Report',
+            imageBase64: MINIMAL_JPEG_BASE64,
+            mimeType: 'image/jpeg',
+            caption: 'A sample image',
+        });
+        expect(result.mode).toBe('base64');
+        expect(result.sizeBytes).toBeGreaterThan(100);
+        expect(decode(result.base64!)).toBe(PDF_HEADER);
+    });
+
+    it('wraps pdfnative image errors as ToolError (e.g. alpha-channel PNG not supported)', async () => {
+        // The minimal PNG used here has an alpha channel (color type 6), which pdfnative does not support.
+        // The tool must wrap this as a ToolError with a descriptive message.
+        await expect(
+            embedImage({
+                title: 'PNG Report',
+                imageBase64: MINIMAL_PNG_BASE64,
+                mimeType: 'image/png',
+                width: 100,
+                height: 100,
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('rejects JPEG bytes declared as PNG', async () => {
+        await expect(
+            embedImage({
+                title: 'Bad mime',
+                imageBase64: MINIMAL_JPEG_BASE64,
+                mimeType: 'image/png',
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('rejects PNG bytes declared as JPEG', async () => {
+        await expect(
+            embedImage({
+                title: 'Bad mime',
+                imageBase64: MINIMAL_PNG_BASE64,
+                mimeType: 'image/jpeg',
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('rejects invalid base64', async () => {
+        await expect(
+            embedImage({
+                title: 'Invalid',
+                imageBase64: '!!!not_base64!!!',
+                mimeType: 'image/jpeg',
+            }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('rejects missing required fields', async () => {
+        await expect(embedImage({ title: 'T', mimeType: 'image/jpeg' })).rejects.toThrow(ToolError);
+        await expect(embedImage({ imageBase64: MINIMAL_JPEG_BASE64 })).rejects.toThrow(ToolError);
+    });
+});

--- a/tests/prepare-signature-placeholder.test.ts
+++ b/tests/prepare-signature-placeholder.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { prepareSignaturePlaceholder } from '../src/tools/prepare-signature-placeholder.js';
+import { ensureCompressionReady } from '../src/server.js';
+import { ToolError } from '../src/errors.js';
+
+beforeAll(async () => {
+    delete process.env['PDFNATIVE_MPC_OUTPUT_DIR'];
+    await ensureCompressionReady();
+});
+
+const PDF_HEADER = '%PDF-';
+
+function decode(b64: string): string {
+    return Buffer.from(b64, 'base64').toString('latin1').slice(0, 5);
+}
+
+function decodeAll(b64: string): string {
+    return Buffer.from(b64, 'base64').toString('latin1');
+}
+
+describe('prepare_signature_placeholder', () => {
+    it('produces a valid PDF with a /Sig placeholder', async () => {
+        const result = await prepareSignaturePlaceholder({ title: 'Contract' });
+        expect(result.mode).toBe('base64');
+        expect(result.sizeBytes).toBeGreaterThan(200);
+        expect(decode(result.base64!)).toBe(PDF_HEADER);
+
+        // Must contain the /Contents hex placeholder required by signPdfBytes
+        const pdfStr = decodeAll(result.base64!);
+        expect(pdfStr).toContain('/Contents <');
+        // Must contain the ByteRange placeholder
+        expect(pdfStr).toContain('/ByteRange [');
+        // Must contain the AcroForm entry
+        expect(pdfStr).toContain('/AcroForm');
+        // Must contain a Widget annotation
+        expect(pdfStr).toContain('/Widget');
+    });
+
+    it('embeds signer metadata in the /Sig dict', async () => {
+        const result = await prepareSignaturePlaceholder({
+            title: 'Agreement',
+            signerName: 'Alice',
+            reason: 'Approved',
+            location: 'Paris',
+            contactInfo: 'alice@example.com',
+        });
+        const pdfStr = decodeAll(result.base64!);
+        expect(pdfStr).toContain('Alice');
+        expect(pdfStr).toContain('Approved');
+        expect(pdfStr).toContain('Paris');
+    });
+
+    it('accepts optional document body blocks', async () => {
+        const result = await prepareSignaturePlaceholder({
+            title: 'Multi-section Contract',
+            blocks: [
+                { type: 'heading', text: 'Terms and Conditions', level: 1 },
+                { type: 'paragraph', text: 'The parties agree to the following.' },
+                { type: 'spacer', height: 20 },
+            ],
+        });
+        expect(result.mode).toBe('base64');
+        const pdfStr = decodeAll(result.base64!);
+        expect(pdfStr).toContain('/Contents <');
+    });
+
+    it('produces a PDF usable by signPdfBytes (structural check)', async () => {
+        const result = await prepareSignaturePlaceholder({ title: 'Sign Me' });
+        const pdfBytes = Buffer.from(result.base64!, 'base64');
+        const pdfLatin = pdfBytes.toString('latin1');
+
+        // signPdfBytes needs: /Contents <hex>, /ByteRange [0 ...], /AcroForm
+        expect(pdfLatin.indexOf('/Contents <')).toBeGreaterThan(-1);
+        expect(pdfLatin.indexOf('/ByteRange [')).toBeGreaterThan(-1);
+        // The SigFlags=3 in AcroForm indicates this document allows signing
+        expect(pdfLatin).toContain('SigFlags');
+    });
+
+    it('rejects an empty title', async () => {
+        await expect(prepareSignaturePlaceholder({ title: '' })).rejects.toThrow(ToolError);
+    });
+
+    it('rejects missing title', async () => {
+        await expect(prepareSignaturePlaceholder({})).rejects.toThrow(ToolError);
+    });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -14,7 +14,7 @@ describe('server', () => {
 
     it('exposes stable metadata', () => {
         expect(__serverMetadata.name).toBe('pdfnative-mcp');
-        expect(__serverMetadata.version).toBe('0.1.0');
+        expect(__serverMetadata.version).toBe('0.2.0');
     });
 
     it('lists all tools', async () => {
@@ -29,8 +29,12 @@ describe('server', () => {
         const names = response.tools.map((t) => t.name).sort();
         expect(names).toEqual([
             'add_barcode',
+            'add_form',
             'add_international_text',
+            'add_table',
+            'embed_image',
             'generate_basic_pdf',
+            'prepare_signature_placeholder',
             'sign_pdf',
         ]);
     });


### PR DESCRIPTION
## Description

This PR implements the complete v0.2.0 roadmap for pdfnative-mcp.

Main additions:
- 4 new tools: add_table, add_form, embed_image, prepare_signature_placeholder.
- Complete two-step signing workflow: prepare_signature_placeholder -> sign_pdf.
- Optional Streamable HTTP MCP transport via PDFNATIVE_MCP_PORT.
- Release/documentation updates: README, CHANGELOG, release-notes/v0.2.0.md.

Validation summary:
- Full quality gate passes: typecheck, lint, tests, coverage, build.
- Coverage thresholds are met (Statements 94.91%, Branches 81.22%, Functions 97.72%, Lines 96%).
- Sandbox protections validated in output tests (path traversal, absolute path, NUL byte, non-.pdf extension blocked; file output blocked when sandbox env is unset).

Compatibility:
- No breaking changes for v0.1.0 users.
- Existing tool contracts remain stable; tools/list now returns 8 tools instead of 4.

## Related Issues

Fixes #<issue-v0.2.0>
Relates to roadmap v0.2.0.

## Checklist

- [x] Tests pass (`npm run test`)
- [x] Type check passes (`npm run typecheck:all`)
- [x] Lint passes (`npm run lint`)
- [x] New code has tests
- [x] CHANGELOG.md updated (if user-facing change)
- [x] No breaking changes (or documented in description)

Closes #8