### PR TITLE
release: v1.3.0 — page-tree tools, pdfnative 1.4 features, constant-t…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-MCP server bridging pdfnative (v1.3.x) to AI clients over stdio. 13 tools.
+MCP server bridging pdfnative (v1.4.x) to AI clients over stdio. 17 tools.
 Quality bar: production-grade OSS (strict TypeScript, strong validation, secure
 file IO, deterministic releases).
 

--- a/.github/drafts/pr-v1.3.0.md
+++ b/.github/drafts/pr-v1.3.0.md
@@ -1,0 +1,92 @@
+# PR: v1.3.0 — page-tree tools, pdfnative 1.4 features, constant-time signing
+
+## Summary
+
+A minor, fully backward-compatible release that extends pdfnative-mcp to **17 tools** and threads the new [pdfnative v1.4.0](https://github.com/Nizoka/pdfnative) capabilities through the server. Adds three **page-tree tools** — `merge_pdfs`, `split_pdf`, `extract_pages` — finally unblocking the long-deferred roadmap items now that pdfnative exports a safe page-tree API. Threads pdfnative 1.4's **document features** (bookmarks/`outline`, `pageLabels`, nested `list` items, `viewerPreferences`, table `cellBorders`/`cellVAlign`) into the authoring tools, and hardens `sign_pdf` with a per-call constant-time **`node:crypto` signature provider** (transparent pure-JS fallback). No breaking changes — all v1.2.0 tool calls work unchanged and default responses are byte-identical.
+
+Full notes: [`release-notes/v1.3.0.md`](../../release-notes/v1.3.0.md).
+
+## Scope
+
+| Phase | Subject |
+| --- | --- |
+| 0 | Branch + version bump (package.json `1.3.0`, pdfnative pin `^1.4.0`) |
+| 1 | Page-tree tools: `emitPdfMulti` + `MultiOutputResult` (`src/output.ts`), `src/pagetree.ts` error mapping, `merge_pdfs`, `split_pdf`, `extract_pages` |
+| 2 | Document features: `src/doc-features.ts` (outline / page labels / viewer prefs / nested lists) threaded into `generate_basic_pdf`, `add_table` (`cellBorders`/`cellVAlign`), `add_international_text` |
+| 3 | Constant-time signing: `src/crypto-provider.ts` (`node:crypto`) wired into `sign_pdf` with pure-JS fallback |
+| 4 | Server registration (3 tools, `MULTI_PDF_OUTPUT_SCHEMA`, dispatch, `SERVER_VERSION`/`apiVersion` → 1.3.0, decision tree); `index.ts`, `server.json` |
+| 5 | Tests: page-tree fixtures + 6 new suites + extended `output.test.ts`; `server.test.ts` → 17 tools / 1.3.0 |
+| 6 | Examples: `merge-pdfs`, `split-pdf`, `extract-pages`, `bookmarked-report`, `bordered-table` |
+| 7 | Docs: README, AGENTS.md, AI_GUIDE, API_STABILITY, KNOWLEDGE_BASE, LOCAL_TESTING, ROADMAP, llms.txt, copilot-instructions |
+| 8 | Security & spec alignment: HTTP DNS-rebinding protection (cli.ts), `serverInfo` title/description (server.ts), JSON-Schema-2020-12 dialect guard, MCP-2025-11-25 protocol notes |
+| 9 | Release: `release-notes/v1.3.0.md`, CHANGELOG mirror, this PR draft |
+
+## Closes
+
+- Roadmap: ships the previously **blocked-upstream** page-tree tools `merge_pdfs`, `split_pdf`, plus the new `extract_pages` (pdfnative v1.4.0 page-tree export API).
+- `redact_pdf` and an encrypted-PDF round-trip remain deferred (blocked on upstream pdfnative content-redaction / Standard Security Handler writer APIs).
+
+## Quality gate
+
+- ✅ `npm run typecheck:all` — 0 errors
+- ✅ `npm run lint` — 0 errors (36 pre-existing non-null-assertion warnings in untouched files)
+- ✅ `npm run test:coverage` — **306 tests** passing; **89.96** stmts / **78.85** branches / **95.43** funcs / **92.14** lines (≥ vitest thresholds 88 / 75 / 85 / 90)
+- ✅ `npm run build` — clean `dist/`
+- ✅ `npm run examples:check` — every `examples/*.json` references a live tool; self-contained examples execute and pass `assertValidPdf`
+
+## Changes summary
+
+### Added
+- **Tool `merge_pdfs`** (new, 15th) — concatenate 2–50 PDFs (`pdfsBase64[]`) into one via pdfnative's page-tree API. Optional `dropAnnotations`/`maxOutputSizeBytes`; standard `outputMode`/`outputPath`. Encrypted sources → `ENCRYPTED_SOURCE`; oversize output → `OUTPUT_TOO_LARGE` (shared `src/pagetree.ts`).
+- **Tool `split_pdf`** (new, 16th) — split one PDF into one document per page range (`ranges: [{ start, end? }]`, 0-based inclusive; `end` defaults to `start`, validated `end >= start`). Returns the new `MultiOutputResult` (`{ mode, count, totalSizeBytes, parts[] }`); file mode writes indexed paths (`report.pdf` → `report-1.pdf`, …).
+- **Tool `extract_pages`** (new, 17th) — pull an arbitrary page subset (`pages: number[]`, 0-based, max 5000, order preserved) into a single PDF.
+- **`generate_basic_pdf`** — optional `outline` (`'auto'` or explicit `[{ title, pageIndex, children?, open? }]` tree, depth ≤ 6), `pageLabels` (`[{ startPage, style?, prefix?, start? }]`), nested `list` items (`{ text, items?, style? }`, depth ≤ 6), and `viewerPreferences`.
+- **`add_table`** — optional `cellBorders` ({ top?, right?, bottom?, left?, color?, width? }), `cellVAlign` (`'top'|'middle'|'bottom'`), and `viewerPreferences` (any forces the document backend).
+- **`add_international_text`** — optional `viewerPreferences`.
+- **`src/crypto-provider.ts`** — `buildNodeCryptoProvider()` returns a per-call `node:crypto` `CryptoProvider` (RSA PKCS#1/PKCS#8; ECDSA P-256 SEC1/PKCS#8, DER signatures), or `null` on import failure.
+- **`src/output.ts`** — `emitPdfMulti()` + `MultiOutputResult`/`MultiOutputPart` (per-part 50 MiB cap, 200 MiB aggregate); `indexedOutputPath()` helper.
+- **`src/doc-features.ts`** — shared Zod schemas + mappers (nested lists, outline, page labels, viewer preferences) reused across authoring tools.
+- **`src/pagetree.ts`** — `mapPageTreeError()` centralises page-tree error mapping.
+- **Security (HTTP transport):** the optional Streamable HTTP transport (`PDFNATIVE_MCP_PORT`) enables DNS-rebinding protection — `enableDnsRebindingProtection` + `allowedHosts`/`allowedOrigins` pinned to the loopback authority; foreign `Host`/`Origin` → **403** (MCP Security Best Practices). stdio unaffected.
+- **`serverInfo` metadata:** advertises `title` + `description` (MCP `Implementation`, mirroring `server.json`).
+- **Examples** — `merge-pdfs.json`, `split-pdf.json`, `extract-pages.json`, `bookmarked-report.json`, `bordered-table.json` (executable, guarded by examples-as-tests).
+- **Tests** — `merge-pdfs.test.ts`, `split-pdf.test.ts`, `extract-pages.test.ts`, `crypto-provider.test.ts`, `sign-pdf-provider.test.ts`, `doc-features.test.ts`, `http-transport.test.ts` (DNS-rebinding 403), a JSON-Schema-2020-12 dialect guard + `serverInfo` metadata assertions in `server.test.ts`, `_pagetree-fixtures.ts`; extended `output.test.ts`.
+
+### Changed
+- **Dependency:** `pdfnative` `^1.3.0` → `^1.4.0` (additive — page-tree, outline, page-label, viewer-preference, nested-list, cell-border APIs).
+- **Signing:** RSA and EC-DER paths sign through the `node:crypto` provider (constant-time) with a transparent pure-JS fallback when key import fails; the raw-scalar `ecPrivateScalarHex` path stays pure-JS. Produced signatures are interoperable and verify identically with `verify_pdf`.
+- **MCP `_meta.apiVersion`** bumped `1.2.0` → `1.3.0` on every tool; `SERVER_VERSION` and `server.json` versions → `1.3.0`.
+- **Server:** `SERVER_INSTRUCTIONS` decision tree extended to 17 tools (combine/carve branch + page-tree, signing, nested-list pitfalls); new `MULTI_PDF_OUTPUT_SCHEMA` advertised for `split_pdf`; `dispatchOutput` handles the multi-output shape first.
+- **Tool count assertion** in `tests/server.test.ts` — 14 → 17.
+- **MCP protocol alignment:** built on `@modelcontextprotocol/sdk` ^1.29, which negotiates the latest **2025-11-25** revision (fallback `2025-06-18`/`2025-03-26`); tool schemas are JSON Schema 2020-12 (dialect-agnostic); `merge_pdfs`' `maxOutputSizeBytes` documented as the in-memory assembly guard (distinct from the 50 MiB emit cap).
+- **Docs:** README, `AGENTS.md`, `docs/AI_GUIDE.md`, `docs/API_STABILITY.md`, `docs/KNOWLEDGE_BASE.md`, `docs/guides/LOCAL_TESTING.md`, `ROADMAP.md`, `llms.txt`, and `.github/copilot-instructions.md` refreshed for the 17-tool / pdfnative-1.4 surface + protocol alignment.
+
+## Deferred (with rationale)
+
+- **`redact_pdf`** — pdfnative does not yet export an annotation read/write or content-stream redaction API. Building it on raw primitives would be production-unsafe. Blocked upstream.
+- **Encrypted-PDF round-trip fixtures** — once pdfnative exposes a Standard Security Handler writer.
+- **Per-tool HTTP page-by-page streaming** — once MCP allows partial `structuredContent` envelopes.
+
+## Reviewer checklist
+
+- [ ] CHANGELOG.md v1.3.0 entry mirrors `release-notes/v1.3.0.md`
+- [ ] `package.json` version === `server.json` versions === `SERVER_VERSION` === `1.3.0`
+- [ ] Tool count assertion in `tests/server.test.ts` equals 17; list includes `merge_pdfs`, `split_pdf`, `extract_pages`
+- [ ] Every tool exposes `_meta.apiVersion === '1.3.0'` and a non-empty `_meta.examples` array
+- [ ] Page-tree tools reject encrypted sources with `ENCRYPTED_SOURCE`; oversize output → `OUTPUT_TOO_LARGE`
+- [ ] `split_pdf` returns the multi-output shape `{ mode, count, totalSizeBytes, parts[] }`; file mode writes indexed paths
+- [ ] `outline` / `pageLabels` / nested `list` items / `viewerPreferences` produce the expected catalog entries; omitting them = byte-identical output
+- [ ] `add_table` `cellBorders` / `cellVAlign` force the document backend; default output unchanged
+- [ ] `sign_pdf` constant-time `node:crypto` path verifies identically with `verify_pdf`; pure-JS fallback path covered (RSA PKCS#1, EC PKCS#8/SEC1, raw scalar)
+- [ ] `SERVER_INSTRUCTIONS` decision tree lists 17 tools incl. the combine/carve branch
+- [ ] HTTP transport rejects a foreign `Host`/`Origin` with **403** and accepts the loopback authority (covered by `http-transport.test.ts`)
+- [ ] `serverInfo` advertises `title` + `description`; tool schemas pass the JSON-Schema-2020-12 dialect guard
+- [ ] `server.json` validates against the MCP registry schema
+- [ ] No `any` added in `src/`; no new CodeQL alerts
+- [ ] Test coverage ≥ vitest thresholds (88 / 75 / 85 / 90)
+
+## Notes for the merger
+
+- No breaking changes; minor bump per [`docs/API_STABILITY.md`](../../docs/API_STABILITY.md) §3 (new tools + new optional inputs).
+- Publish is via GitHub Actions Trusted Publishing (OIDC) — no `NPM_TOKEN`.
+- GitHub Release title: `v1.3.0 — page-tree tools, pdfnative 1.4 features, constant-time signing`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,24 +13,29 @@ invocations live under [examples/](examples/).
 
 ---
 
-## 1. Tool catalogue (14 tools)
+## 1. Tool catalogue (17 tools)
 
 | # | Tool | Use it for | Read-only |
 |---|------|-----------|:---:|
-| 1 | `generate_basic_pdf` | Plain documents (headings, paragraphs, lists). Optional `pdfA`, `watermark`, `normalize`. | |
+| 1 | `generate_basic_pdf` | Plain documents (headings, paragraphs, nested lists). Optional `pdfA`, `watermark`, `normalize`, `outline` (bookmarks), `pageLabels`, `viewerPreferences`. | |
 | 2 | `add_barcode` | QR / Code 128 / EAN-13 / Data Matrix / PDF417. | |
-| 3 | `add_international_text` | 24 scripts + colour emoji, BiDi + OpenType shaping. Optional `normalize` (default `NFC`). | |
-| 4 | `add_table` | Tabular reports (wrap, repeatHeader, zebra, caption…). Optional `watermark`. | |
+| 3 | `add_international_text` | 24 scripts + colour emoji, BiDi + OpenType shaping. Optional `normalize` (default `NFC`), `viewerPreferences`. | |
+| 4 | `add_table` | Tabular reports (wrap, repeatHeader, zebra, caption, `cellBorders`, `cellVAlign`…). Optional `watermark`, `viewerPreferences`. | |
 | 5 | `add_form` | Interactive AcroForms (text, checkbox, radio, dropdown). | |
 | 6 | `embed_image` | Embed a JPEG/PNG into a titled PDF. | |
 | 7 | `prepare_signature_placeholder` | Customize the `/Sig` placeholder before signing. | |
-| 8 | `sign_pdf` | PAdES CMS signature (RSA-SHA256 / ECDSA-P256). Auto-injects a placeholder. | |
+| 8 | `sign_pdf` | PAdES CMS signature (RSA-SHA256 / ECDSA-P256), constant-time via `node:crypto`. Auto-injects a placeholder. | |
 | 9 | `verify_pdf` | Verify every PAdES signature (integrity + value + chain). | ✓ |
 | 10 | `validate_pdf` | PDF/UA (ISO 14289-1) structural conformance. | ✓ |
 | 11 | `inspect_pdf` | Metadata: version, pages, encryption, PDF/A, signatures, attachments. | ✓ |
 | 12 | `add_attachment` | PDF/A-3 with embedded files (Factur-X / ZUGFeRD). | |
 | 13 | `extract_attachments` | Read embedded files back out (byte-for-byte). | ✓ |
 | 14 | `extract_text` | Best-effort plain-text extraction (non-encrypted). | ✓ |
+| 15 | `merge_pdfs` | Concatenate 2–50 PDFs into one (page-tree API). | |
+| 16 | `split_pdf` | Split a PDF into one document per page range (multi-output). | |
+| 17 | `extract_pages` | Pull an arbitrary page subset into a single PDF. | ✓¹ |
+
+¹ `extract_pages` only reads the source, but it produces a new PDF, so it is not annotated `readOnlyHint`.
 
 ## 2. Decision tree
 
@@ -43,6 +48,10 @@ Need a NEW PDF?
  ├─ an image?                              → embed_image
  ├─ an interactive form?                   → add_form
  └─ otherwise                              → generate_basic_pdf
+Combine / carve existing PDFs?
+ ├─ join several into one?                 → merge_pdfs
+ ├─ split into per-range documents?        → split_pdf
+ └─ keep an arbitrary page subset (1 PDF)? → extract_pages
 Need to SIGN?            → sign_pdf  (then verify_pdf)
 Need to READ a PDF?
  ├─ metadata/structure?  → inspect_pdf
@@ -77,7 +86,8 @@ content block (`data:application/pdf;base64,…`), not duplicated into
 
 **Privacy:** no telemetry, no outbound network calls — document bytes only ever
 flow back in the JSON-RPC response. The optional HTTP transport
-(`PDFNATIVE_MCP_PORT`) binds `127.0.0.1` only. Embedded files are passed through
+(`PDFNATIVE_MCP_PORT`) binds `127.0.0.1` only and enables DNS-rebinding
+protection (foreign `Host`/`Origin` → 403). Embedded files are passed through
 verbatim — the server never executes, renders, or scans them, so scan untrusted
 attachments in the caller.
 
@@ -87,6 +97,8 @@ attachments in the caller.
 - **Sign & verify:** `sign_pdf` → `verify_pdf` (add `trustedRootsDerBase64` for chain trust).
 - **Author PDF/A:** `generate_basic_pdf` / `add_table` with `pdfA: 'pdfa2b'` → `validate_pdf`.
 - **Watermarked report:** `add_table` with `watermark: { text: 'CONFIDENTIAL', opacity: 0.2 }`.
+- **Bookmarked report:** `generate_basic_pdf` with `outline: 'auto'` + `pageLabels` + `viewerPreferences: { pageMode: 'useOutlines' }`.
+- **Assemble / carve:** generate parts → `merge_pdfs`; or `split_pdf` (per range) / `extract_pages` (one subset) → `inspect_pdf` to confirm the page count.
 
 ## 6. Error reference
 
@@ -97,6 +109,7 @@ attachments in the caller.
 | `PDF_A_COMPLIANCE_VIOLATION` | Watermark `opacity < 1.0` (incl. 0.15 default) under `pdfA:'pdfa1b'` | Use `opacity:1.0`, or target `pdfa2b`/`pdfa3b` (allow transparency). |
 | `MISSING_PLACEHOLDER` | `sign_pdf` w/ `autoInjectPlaceholder:false` on unplaceheld PDF | Keep the default `true`, or run `prepare_signature_placeholder`. |
 | `EXTRACTION_UNSUPPORTED` | Encrypted PDF to `extract_text` / `extract_attachments` | Decrypt outside the server first. |
+| `ENCRYPTED_SOURCE` | Encrypted source to `merge_pdfs` / `split_pdf` / `extract_pages` | Decrypt outside the server first; the page-tree API rejects encrypted input. |
 | `ATTACHMENT_NOT_FOUND` | `extract_attachments` `filename` matched nothing | Drop `filename` or list names via `inspect_pdf`. |
 | `ATTACHMENT_TOO_LARGE` | `add_attachment` payload > 8 MiB | Shrink/split the payload. |
 | `OUTPUT_TOO_LARGE` | PDF > 50 MiB, or extraction > 16 MiB/file · 32 MiB total | Reduce content; for extraction use `includeData:false` or `filename`. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-07
+
+A minor, backward-compatible release that adds three page-tree tools
+(`merge_pdfs`, `split_pdf`, `extract_pages` — taking the catalogue to **17 tools**),
+threads the new [pdfnative v1.4.0](https://github.com/Nizoka/pdfnative) document
+features (bookmarks, page labels, nested lists, viewer preferences, table cell
+borders) into the authoring tools, and hardens `sign_pdf` with a constant-time
+`node:crypto` signature provider (transparent pure-JS fallback). Default tool calls
+return responses identical to v1.2.0 — all new behaviour is opt-in.
+
+### Added
+
+- **Tool `merge_pdfs`** (new): concatenate 2–50 PDFs (`pdfsBase64[]`) into one via pdfnative's page-tree API. Optional `dropAnnotations`/`maxOutputSizeBytes`. Encrypted sources → `ENCRYPTED_SOURCE`; oversize output → `OUTPUT_TOO_LARGE`.
+- **Tool `split_pdf`** (new): split one PDF into one document per page range (`ranges: [{ start, end? }]`, 0-based inclusive). Returns the new multi-output shape `{ mode, count, totalSizeBytes, parts[] }`; file mode writes indexed paths (`report-1.pdf`, …).
+- **Tool `extract_pages`** (new): pull an arbitrary page subset (`pages: number[]`, 0-based, max 5000) into a single PDF.
+- **`generate_basic_pdf`**: optional `outline` (`'auto'` or explicit `[{ title, pageIndex, children?, open? }]` tree), `pageLabels` (`[{ startPage, style?, prefix?, start? }]`), nested `list` items (`{ text, items?, style? }`), and `viewerPreferences`.
+- **`add_table`**: optional `cellBorders`, `cellVAlign` (`'top'|'middle'|'bottom'`), and `viewerPreferences` (any forces the document backend).
+- **`add_international_text`**: optional `viewerPreferences`.
+- **Signing:** new `src/crypto-provider.ts` constant-time `node:crypto` provider; new `emitPdfMulti()` + `MultiOutputResult`/`MultiOutputPart` in `src/output.ts`; new `src/pagetree.ts` error mapping; new `src/doc-features.ts` shared schemas/mappers.
+- **Security (HTTP transport):** the optional Streamable HTTP transport (`PDFNATIVE_MCP_PORT`) now enables DNS-rebinding protection — `Host`/`Origin` pinned to the loopback authority; foreign values are rejected with **403** (MCP Security Best Practices). stdio is unaffected.
+- **serverInfo metadata:** the server now advertises a human-readable `title` + `description` (MCP `Implementation`, mirroring `server.json`).
+- **Examples:** `merge-pdfs.json`, `split-pdf.json`, `extract-pages.json`, `bookmarked-report.json`, `bordered-table.json`.
+- **Tests:** `merge-pdfs.test.ts`, `split-pdf.test.ts`, `extract-pages.test.ts`, `crypto-provider.test.ts`, `sign-pdf-provider.test.ts`, `doc-features.test.ts`, `http-transport.test.ts` (DNS-rebinding 403), a JSON-Schema-2020-12 dialect guard + `serverInfo` metadata assertions, `_pagetree-fixtures.ts`.
+
+### Changed
+
+- **Dependency:** `pdfnative` bumped `^1.3.0` → `^1.4.0` (additive; new page-tree, outline, page-label, viewer-preference, nested-list, and cell-border APIs).
+- **Signing:** RSA and EC-DER keys now sign through a per-call `node:crypto` provider (constant-time) with a transparent pure-JS fallback; the raw-scalar `ecPrivateScalarHex` path stays pure-JS. Produced signatures are interoperable and verify identically.
+- **MCP `_meta.apiVersion`** bumped `1.2.0` → `1.3.0` on every tool; `SERVER_VERSION` and `server.json` versions → `1.3.0`.
+- **Server:** `SERVER_INSTRUCTIONS` decision tree extended to 17 tools; new `MULTI_PDF_OUTPUT_SCHEMA` advertised for `split_pdf`.
+- **MCP protocol alignment:** built on `@modelcontextprotocol/sdk` ^1.29, which negotiates the latest **2025-11-25** revision (fallback `2025-06-18`/`2025-03-26`); tool schemas are JSON Schema 2020-12 (dialect-agnostic); `merge_pdfs`' `maxOutputSizeBytes` documented as the in-memory assembly guard (distinct from the 50 MiB emit cap).
+- **Docs:** README, `AGENTS.md`, `docs/AI_GUIDE.md`, `docs/API_STABILITY.md`, `docs/KNOWLEDGE_BASE.md`, `docs/guides/LOCAL_TESTING.md`, `ROADMAP.md`, `llms.txt`, and `.github/copilot-instructions.md` refreshed for the v1.3.0 surface + protocol alignment.
+
+### Deferred (still blocked upstream)
+
+- **`redact_pdf`** and an **encrypted-PDF round-trip** — pdfnative does not yet export a content-redaction API or a Standard Security Handler writer. Remain on the roadmap. (`merge_pdfs`, `split_pdf`, `extract_pages` shipped in this release.)
+
 ## [1.2.0] - 2026-06-23
 
 A minor, backward-compatible release that adds a 14th tool (`extract_attachments`),
@@ -181,7 +218,8 @@ stability via the new per-tool `_meta.apiVersion` field. Built on top of
 - Strict JSON Schema + Zod validation at every tool boundary.
 - Vitest test suite with sandbox security checks.
 
-[Unreleased]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/Nizoka/pdfnative-mcp/compare/v0.3.0...v1.0.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## ✨ Features
 
-`pdfnative-mcp` exposes **14 production-grade tools** to any MCP host:
+`pdfnative-mcp` exposes **17 production-grade tools** to any MCP host:
 
 | Tool                               | Purpose                                                                                          |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------ |
@@ -34,8 +34,17 @@
 | `extract_attachments`              | Read-only extraction of embedded files (Factur-X / ZUGFeRD XML round-trip) with byte-for-byte payloads. |
 | `extract_text`                     | Best-effort plain-text extraction from a non-encrypted PDF.                                     |
 | `inspect_pdf`                      | Read-only inspection: PDF version, page count, encryption, PDF/A claim, signatures, attachments, placeholder state. |
+| `merge_pdfs` *(new in v1.3.0)*     | Concatenate 2–50 PDFs into one via pdfnative's page-tree API.                                  |
+| `split_pdf` *(new in v1.3.0)*      | Split one PDF into one document per page range (multi-output).                                  |
+| `extract_pages` *(new in v1.3.0)*  | Pull an arbitrary page subset into a single PDF.                                               |
 
-**New in v1.2.0:**
+**New in v1.3.0:**
+
+- 🆕 **Three page-tree tools** — `merge_pdfs`, `split_pdf`, `extract_pages` (built on [pdfnative v1.4.0](https://github.com/Nizoka/pdfnative)'s page-tree API; encrypted sources are rejected).
+- 🔖 **Bookmarks, page labels & nested lists** — `generate_basic_pdf` gains `outline` (`'auto'` or explicit tree), `pageLabels`, multi-level `list` items, and `viewerPreferences`.
+- 📐 **Table cell borders & alignment** — `add_table` gains `cellBorders`, `cellVAlign`, and `viewerPreferences`; `add_international_text` gains `viewerPreferences`.
+- 🔐 **Constant-time signing** — `sign_pdf` signs RSA and EC-DER keys through a `node:crypto` provider with a transparent pure-JS fallback; signatures stay interoperable.
+- ⬆ **Engine upgrade** — pdfnative **v1.4.0**.
 
 - 🆕 **Tool `extract_attachments`** — read embedded files back out of a PDF (completes the Factur-X / ZUGFeRD round-trip) with byte-for-byte payloads, a `filename` filter, and an `includeData: false` metadata-only probe.
 - 💧 **Watermarks** — `generate_basic_pdf` and `add_table` accept an optional `watermark` (text, opacity, angle, colour, position) rendered on every page.
@@ -65,7 +74,7 @@
 - 🆕 **AI agent guide:** [`docs/AI_GUIDE.md`](docs/AI_GUIDE.md) — decision tree + common pitfalls. See also the root [`AGENTS.md`](AGENTS.md) operations manual.
 - 🆕 **PDF/A authoring guide:** [`docs/guides/PDFA.md`](docs/guides/PDFA.md).
 - 🛠 **Env-var rename:** `PDFNATIVE_MCP_OUTPUT_DIR` (was `PDFNATIVE_MPC_OUTPUT_DIR`; old name still works with a one-shot deprecation warning).
-- ⏭ **Deferred to v1.1:** `merge_pdfs`, `split_pdf`, `redact_pdf` (require pdfnative page-tree primitives not yet exported).
+- ✅ **Now shipped (v1.3.0):** `merge_pdfs`, `split_pdf`, `extract_pages` — built on pdfnative v1.4.0's page-tree API. `redact_pdf` remains blocked upstream.
 
 All tools support two output modes:
 
@@ -161,7 +170,7 @@ Any MCP-compatible client that supports stdio servers will work. Use the same `c
 | ----------------------------- | ---------------------------------------------------------------------------------- |
 | `PDFNATIVE_MCP_OUTPUT_DIR`    | Absolute path to the sandbox directory. **Required to enable `outputMode: 'file'`.** |
 | `PDFNATIVE_MCP_CACHE_DIR`     | Absolute path to enable the persistent SHA-256-keyed result cache (1 h TTL, 256 MiB LRU). When unset, the cache is disabled. |
-| `PDFNATIVE_MCP_PORT`          | When set to a valid port (1–65535), starts an HTTP server on `http://127.0.0.1:<port>/mcp` instead of stdio. |
+| `PDFNATIVE_MCP_PORT`          | When set to a valid port (1–65535), starts an HTTP server on `http://127.0.0.1:<port>/mcp` instead of stdio. Binds loopback only and enables DNS-rebinding protection (foreign `Host`/`Origin` → **403**). |
 
 ---
 
@@ -432,8 +441,11 @@ src/
 ├── cli.ts                      # stdio entrypoint (#!/usr/bin/env node)
 ├── index.ts                    # public library exports
 ├── server.ts                   # McpServer factory + tool registry
-├── output.ts                   # sandboxed file writer / base64 emitter
+├── output.ts                   # sandboxed file writer / base64 emitter (single + multi)
 ├── text.ts                     # newline sanitizer (Safe PDF/A)
+├── doc-features.ts             # nested lists, outline, page labels, viewer prefs
+├── pagetree.ts                 # page-tree error mapping (merge/split/extract)
+├── crypto-provider.ts          # node:crypto constant-time signature provider
 ├── errors.ts                   # ToolError, SecurityError
 └── tools/
     ├── generate-basic-pdf.ts
@@ -447,7 +459,11 @@ src/
     ├── verify-pdf.ts
     ├── validate-pdf.ts
     ├── add-attachment.ts
+    ├── extract-attachments.ts
     ├── extract-text.ts
+    ├── merge-pdfs.ts
+    ├── split-pdf.ts
+    ├── extract-pages.ts
     └── prepare-signature-placeholder.ts
 tests/                          # vitest suites
 ```
@@ -456,11 +472,11 @@ tests/                          # vitest suites
 
 ## 🗺 Roadmap
 
-v1.1.0 is shipped. The full plan — released milestones, in-progress work, and long-term direction — lives in [ROADMAP.md](ROADMAP.md).
+v1.3.0 is shipped. The full plan — released milestones, in-progress work, and long-term direction — lives in [ROADMAP.md](ROADMAP.md).
 
 **Blocked upstream (page-tree manipulation):**
 
-- `merge_pdfs`, `split_pdf`, `redact_pdf` — pdfnative does not yet export the page-tree manipulation primitives required to build these safely. They remain on the roadmap, blocked on an upstream API.
+- `redact_pdf` and an encrypted-PDF round-trip — pdfnative does not yet export the content-redaction / decryption primitives required to build these safely. They remain on the roadmap, blocked on an upstream API. (`merge_pdfs`, `split_pdf` and `extract_pages` shipped in v1.3.0.)
 
 Have a feature idea? Open an issue or PR.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,28 +74,35 @@ Priorities may shift based on community feedback and sponsorship.
 - [x] **Dependency** — upgraded to **zod 4**.
 - [x] **AGENTS.md** — root agent operations manual (catalogue, decision tree, recipes, error table).
 
+### v1.3.0 — page-tree tools, pdfnative 1.4 features, constant-time signing
+
+- [x] **pdfnative v1.4.0** — dependency bump `^1.3.0` → `^1.4.0` (additive, no breaking changes).
+- [x] **Tool `merge_pdfs`** — concatenate 2–50 PDFs into one via pdfnative's page-tree API; rejects encrypted sources. **15th tool.**
+- [x] **Tool `split_pdf`** — split one PDF into one document per page range (multi-output `{ count, totalSizeBytes, parts[] }`). **16th tool.**
+- [x] **Tool `extract_pages`** — pull an arbitrary page subset into a single PDF. **17th tool.**
+- [x] **Bookmarks & page labels** — `generate_basic_pdf` gains `outline` (`'auto'` or explicit tree), `pageLabels`, and nested multi-level `list` items.
+- [x] **Viewer preferences** — optional `viewerPreferences` on `generate_basic_pdf`, `add_table`, and `add_international_text`.
+- [x] **Table cell borders & alignment** — `add_table` gains `cellBorders` and `cellVAlign`.
+- [x] **Constant-time signing** — `sign_pdf` signs RSA and EC-DER keys through a `node:crypto` provider with a transparent pure-JS fallback; signatures stay interoperable.
+
 ---
 
 ## In Progress
 
-_v1.2.0 is the active release. Page-tree manipulation tools remain blocked on an upstream pdfnative page-tree export API (see Blocked below)._
+_v1.3.0 is the active release. `redact_pdf` and an encrypted-PDF round-trip remain blocked on upstream pdfnative APIs (see Blocked below)._
 
 ---
 
 ## Planned
 
-### Blocked upstream — Page-tree manipulation
+### Blocked upstream
 
-These tools were originally scoped for v1.1.0 but remain **blocked**: pdfnative
-v1.3.0 still exposes only incremental object-update primitives (`openPdf`,
-`createModifier`), not the page-tree export/merge/extract API required to build
-them safely. Implementing them on raw primitives would mean production-unsafe
-page-tree surgery (relocating `/Kids`, rewriting `/Parent` chains, merging
-resource pools), which contradicts this project's faithful, thin-wrapper
-philosophy. They will ship once pdfnative exports a page-tree manipulation API.
+`merge_pdfs`, `split_pdf` and `extract_pages` shipped in v1.3.0 on pdfnative
+v1.4.0's page-tree export API. The remaining items stay **blocked**: pdfnative
+does not yet export a content-redaction API or a Standard Security Handler writer,
+and implementing them on raw primitives would contradict this project's faithful,
+thin-wrapper philosophy. They will ship once pdfnative exports the required APIs.
 
-- [ ] **Tool `merge_pdfs`** — concatenate 2–50 PDFs, optionally drop signatures; blocked on pdfnative page-tree export.
-- [ ] **Tool `split_pdf`** — extract page ranges into individual PDFs; blocked on pdfnative page-tree export.
 - [ ] **Tool `redact_pdf`** — overlay-mode (annotation rectangles + replacement text); blocked on pdfnative annotation read/write API. Content-stream redaction tracked separately.
 - [ ] **Encrypted-PDF round-trip fixtures** — once pdfnative exposes a Standard Security Handler writer.
 - [ ] **Per-tool HTTP page-by-page streaming** — once MCP allows partial structuredContent envelopes.

--- a/docs/AI_GUIDE.md
+++ b/docs/AI_GUIDE.md
@@ -1,7 +1,7 @@
 # AI Agent Guide — pdfnative-mcp
 
 > **Read this first if you are an AI agent (Copilot, Claude, Cursor, Continue, Zed, Windsurf, Cline, Roo Code, …) about to call pdfnative-mcp.**
-> It tells you which of the 14 tools to pick and how to avoid the common retry loops.
+> It tells you which of the 17 tools to pick and how to avoid the common retry loops.
 
 The server also returns the same decision tree in `serverInfo.instructions`. The full reference lives in [`KNOWLEDGE_BASE.md`](KNOWLEDGE_BASE.md); the stability charter in [`API_STABILITY.md`](API_STABILITY.md). Worked invocations are in [`../examples/`](../examples).
 
@@ -25,6 +25,9 @@ The server also returns the same decision tree in `serverInfo.instructions`. The
 | Verify all PAdES signatures | `verify_pdf` |
 | Validate PDF/UA accessibility structure | `validate_pdf` |
 | Extract plain text | `extract_text` |
+| Join several PDFs into one | `merge_pdfs` |
+| Split one PDF into per-range documents | `split_pdf` |
+| Keep an arbitrary page subset (one PDF) | `extract_pages` |
 
 ---
 
@@ -44,6 +47,20 @@ The server also returns the same decision tree in `serverInfo.instructions`. The
   - ECDSA key (PKCS#8 or SEC1): `openssl pkey -in key.pem -outform DER | base64 -w0` → `ecPrivateKeyDerBase64`
   - ECDSA scalar form: `ecPrivateScalarHex` = 64 hex chars (raw P-256 `d`)
 - After signing, call `verify_pdf` to confirm. Without `trustedRootsDerBase64`, `chainTrust` is `'self-signed'` or `'unverified'` — that is expected.
+- RSA and EC-DER keys sign through a constant-time `node:crypto` provider (with a transparent pure-JS fallback); the raw-scalar `ecPrivateScalarHex` path uses the pure-JS signer. Signatures are interoperable either way.
+
+### Combining / carving PDFs (page-tree)
+- `merge_pdfs` joins 2–50 PDFs (`pdfsBase64[]`) into one. `split_pdf` cuts one PDF into one document per `ranges[]` entry (`{ start, end? }`, 0-based inclusive). `extract_pages` keeps an arbitrary `pages[]` subset (0-based) in a single PDF.
+- `split_pdf` returns a **multi-output** result (`{ mode, count, totalSizeBytes, parts[] }`); in `file` mode each part is written to an indexed path (`report.pdf` → `report-1.pdf`, …).
+- **Encrypted sources are rejected** with `ENCRYPTED_SOURCE` — decrypt outside the server first. Oversize output throws `OUTPUT_TOO_LARGE`.
+
+### Bookmarks, page labels & nested lists
+- `generate_basic_pdf` accepts `outline: 'auto'` (derive bookmarks from headings) or an explicit `[{ title, pageIndex, children?, open? }]` tree, plus `pageLabels: [{ startPage, style?, prefix?, start? }]` for viewer page numbering.
+- `list` blocks accept nested `items` (`{ text, items?, style? }`, up to 6 levels) for multi-level lists.
+- Pair `outline` with `viewerPreferences: { pageMode: 'useOutlines' }` to open the bookmark pane on load.
+
+### Table cell borders & alignment
+- `add_table` accepts `cellBorders: { top?, right?, bottom?, left?, color?, width? }` and `cellVAlign: 'top' | 'middle' | 'bottom'`. Either forces the document backend (same as `watermark`).
 
 ### Attachments (Factur-X / ZUGFeRD)
 - Use `add_attachment`, **not** `generate_basic_pdf`. The latter cannot embed files.
@@ -117,12 +134,20 @@ Defaults are unchanged: omit both and you get the full v1.1.0-identical response
 1. `add_table` with `watermark: { text: 'CONFIDENTIAL', opacity: 0.2 }`.
 2. *(optional)* `inspect_pdf` to confirm the page count / metadata.
 
+### Bookmarked report
+1. `generate_basic_pdf` with `outline: 'auto'`, `pageLabels`, and `viewerPreferences: { pageMode: 'useOutlines' }`.
+2. *(optional)* `inspect_pdf` to confirm the page count.
+
+### Assemble / carve PDFs
+1. Generate the parts (any authoring tool), then `merge_pdfs` to join them — **or** `split_pdf` (per range) / `extract_pages` (one subset) on an existing PDF.
+2. `inspect_pdf` to confirm the resulting page count.
+
 ---
 
 ## 4. Self-documenting metadata
 
 Every tool ships:
-- `_meta.apiVersion` = `'1.2.0'` — see [`API_STABILITY.md`](API_STABILITY.md).
+- `_meta.apiVersion` = `'1.3.0'` — see [`API_STABILITY.md`](API_STABILITY.md).
 - `_meta.examples`   — at least one worked example per tool. Inspect the `ListTools` response to discover them.
 
 You can rely on these fields when negotiating capabilities before calling a tool.

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -9,12 +9,20 @@
 
 Every tool emits `_meta.apiVersion` in the `ListTools` response.
 
-Current value: **`1.2.0`** (stable, since pdfnative-mcp 1.2.0).
+Current value: **`1.3.0`** (stable, since pdfnative-mcp 1.3.0).
 
 The tool API version is **independent of the npm release version**.
 Server releases that ship only documentation, refactoring, or non-breaking ergonomic improvements (richer descriptions, additional `_meta.examples`, new optional output fields) **do not** bump `_meta.apiVersion`.
 
 A bump of `_meta.apiVersion` happens **only** in the cases listed in §3.
+
+> **MCP protocol alignment.** The tool API version above is orthogonal to the MCP
+> wire-protocol revision. The server runs on `@modelcontextprotocol/sdk` ^1.29, which
+> negotiates the latest revision (**2025-11-25**, falling back to `2025-06-18` /
+> `2025-03-26`). Tool schemas are JSON Schema **2020-12** (the current default dialect),
+> `serverInfo` advertises `title` + `description`, and input-validation failures are
+> returned as tool-execution errors (`isError: true`) — none of which affect
+> `_meta.apiVersion`.
 
 ---
 
@@ -68,11 +76,24 @@ When a tool, field or error code is scheduled for removal:
 
 ## 5. Per-tool stability matrix
 
-All 14 tools shipped in pdfnative-mcp 1.2.0 are at `_meta.apiVersion = '1.2.0'` and are considered **stable**:
+All 17 tools shipped through pdfnative-mcp 1.3.0 are at `_meta.apiVersion = '1.3.0'` and are considered **stable**:
 
 `generate_basic_pdf`, `add_barcode`, `add_international_text`, `add_table`, `add_form`,
 `embed_image`, `prepare_signature_placeholder`, `sign_pdf`, `verify_pdf`, `validate_pdf`,
-`inspect_pdf`, `add_attachment`, `extract_attachments`, `extract_text`.
+`inspect_pdf`, `add_attachment`, `extract_attachments`, `extract_text`,
+`merge_pdfs`, `split_pdf`, `extract_pages`.
+
+> **v1.3.0 minor bump rationale:** three **new tools** (`merge_pdfs`, `split_pdf`,
+> `extract_pages`) were added on pdfnative v1.4.0's page-tree API, and several authoring
+> tools gained **optional** inputs with backward-compatible defaults — `generate_basic_pdf`
+> gained nested-list items, `outline`, `pageLabels`, `viewerPreferences`; `add_table` gained
+> `cellBorders`, `cellVAlign`, `viewerPreferences`; `add_international_text` gained
+> `viewerPreferences`. All are additive per §3 ("new tool" / "new optional input field with a
+> backward-compatible default"). `sign_pdf` now signs through a `node:crypto` provider for
+> RSA and EC-DER keys with a transparent pure-JS fallback — an internal hardening change that
+> leaves input/output shapes and produced signatures interoperable. Default responses for the
+> existing tools are byte-identical to v1.2.0. `split_pdf` introduces a new multi-output
+> response shape (`{ mode, count, totalSizeBytes, parts[] }`), documented in its `outputSchema`.
 
 > **v1.2.0 minor bump rationale:** the read-only tools (`inspect_pdf`, `verify_pdf`,
 > `validate_pdf`, `extract_text`, `extract_attachments`) gained two **optional** inputs —
@@ -95,7 +116,7 @@ All 14 tools shipped in pdfnative-mcp 1.2.0 are at `_meta.apiVersion = '1.2.0'` 
 > satisfy the full `outputSchema` (which describes the default `'full'` shape). This is an
 > opt-in token-saving feature; the `outputSchema` contract continues to describe full output.
 
-Page-tree tools (`merge_pdfs`, `split_pdf`, `redact_pdf`) remain **blocked upstream** — pdfnative does not yet export the required page-tree manipulation API. They will be added with the same stability guarantees once unblocked.
+Page-tree tools `merge_pdfs`, `split_pdf` and `extract_pages` shipped in v1.3.0 on pdfnative v1.4.0's page-tree API. `redact_pdf` and an encrypted-PDF round-trip remain **blocked upstream** — pdfnative does not yet export the required content-redaction / decryption API. They will be added with the same stability guarantees once unblocked.
 
 ---
 

--- a/docs/KNOWLEDGE_BASE.md
+++ b/docs/KNOWLEDGE_BASE.md
@@ -2,7 +2,7 @@
 
 > Reference for AI assistants (GitHub Copilot, Claude, Cursor, Continue, Zed, Windsurf, Cline, Roo Code)
 > and human contributors. Captures the full context needed to understand, extend, and debug
-> pdfnative-mcp **v1.2.0** without reading every source file.
+> pdfnative-mcp **v1.3.0** without reading every source file.
 
 > If you are an AI agent calling pdfnative-mcp from a chat session, also read
 > [`AI_GUIDE.md`](AI_GUIDE.md) — the short, action-oriented decision tree.
@@ -13,17 +13,17 @@
 
 **What is pdfnative-mcp?**
 An MCP (Model Context Protocol) server that bridges the zero-dependency
-[`pdfnative`](https://github.com/Nizoka/pdfnative) library (v1.3.x) to AI clients
+[`pdfnative`](https://github.com/Nizoka/pdfnative) library (v1.4.x) to AI clients
 (Claude Desktop, ChatGPT, Cursor, Continue, Zed, Windsurf, Cline, Roo Code, …).
-It exposes **13** PDF tools over a stdio transport so AI agents can generate, sign,
-verify, validate, attach, inspect and extract PDF files.
+It exposes **17** PDF tools over a stdio transport so AI agents can generate, sign,
+verify, validate, attach, inspect, extract, merge, split and carve PDF files.
 
 **Philosophy:**
 - `pdfnative` is the only runtime dependency — all PDF logic lives there.
 - The MCP server is a thin, secure dispatch layer: validate inputs with Zod → call pdfnative → emit PDF as base64 or to a sandboxed file.
 - Every tool is fully self-contained (its own file in [src/tools/](../src/tools)).
 - Security at every boundary: Zod validation on all inputs, path traversal prevention on file output, no key-material echo in logs or errors.
-- Every tool ships `_meta.apiVersion = '1.2.0'` and worked-example `_meta.examples` so AI clients can introspect supported behavior — see [`API_STABILITY.md`](API_STABILITY.md).
+- Every tool ships `_meta.apiVersion = '1.3.0'` and worked-example `_meta.examples` so AI clients can introspect supported behavior — see [`API_STABILITY.md`](API_STABILITY.md).
 
 **Runtime:** Node.js ≥ 22 (ESM, strict TypeScript). Transport: stdio.
 
@@ -41,11 +41,14 @@ verify, validate, attach, inspect and extract PDF files.
 src/
 ├── cli.ts            # Entry point: stdio transport, signal handling, lazy init
 ├── server.ts         # createServer(): MCP tool registry + request handlers
-├── output.ts         # outputMode logic: base64 inline vs sandboxed file write
+├── output.ts         # outputMode logic: base64 inline vs sandboxed file write (single + multi)
 ├── cache.ts          # In-process LRU cache for idempotent tool results
 ├── text.ts           # newline sanitizer (Safe PDF/A)
 ├── watermark.ts      # shared text-watermark schema + WatermarkOptions mapping
 ├── normalize.ts      # shared Unicode-normalization schema
+├── doc-features.ts   # shared schemas/mappers: nested lists, outline, page labels, viewer prefs
+├── pagetree.ts       # shared page-tree error mapping (merge/split/extract)
+├── crypto-provider.ts# node:crypto constant-time signature provider
 ├── errors.ts         # ToolError + SecurityError
 └── tools/
     ├── generate-basic-pdf.ts          # generate_basic_pdf
@@ -61,7 +64,10 @@ src/
     ├── inspect-pdf.ts                 # inspect_pdf
     ├── add-attachment.ts              # add_attachment (PDF/A-3 / Factur-X)
     ├── extract-attachments.ts         # extract_attachments (read-only)
-    └── extract-text.ts                # extract_text
+    ├── extract-text.ts                # extract_text
+    ├── merge-pdfs.ts                  # merge_pdfs (page-tree)
+    ├── split-pdf.ts                   # split_pdf (page-tree, multi-output)
+    └── extract-pages.ts               # extract_pages (page-tree)
 ```
 
 ### Request Dispatch Flow
@@ -117,19 +123,19 @@ interface ToolDefinition {
         openWorldHint?: boolean;
     };
     examples?: ReadonlyArray<{ title: string; input: Record<string, unknown> }>;
-    handler: (args: unknown) => Promise<OutputResult | InspectPdfResult | VerifyPdfResult | ExtractTextResult | ValidatePdfResult>;
+    handler: (args: unknown) => Promise<OutputResult | MultiOutputResult | InspectPdfResult | VerifyPdfResult | ExtractTextResult | ValidatePdfResult | ExtractAttachmentsResult>;
 }
 ```
 
 A `TOOL_INDEX: ReadonlyMap<string, ToolDefinition>` is derived from the array for O(1) lookup on `CallToolRequest`.
 
 **`_meta` per tool** — emitted in the `ListTools` response so AI clients can introspect:
-- `_meta.apiVersion` = `'1.2.0'` (see [`API_STABILITY.md`](API_STABILITY.md) for the bump policy)
+- `_meta.apiVersion` = `'1.3.0'` (see [`API_STABILITY.md`](API_STABILITY.md) for the bump policy)
 - `_meta.examples`   = at least one worked example per tool
 
 **Server metadata:**
 - `SERVER_NAME = 'pdfnative-mcp'`
-- `SERVER_VERSION = '1.2.0'`
+- `SERVER_VERSION = '1.3.0'`
 - `serverInfo._meta.mcpName = 'io.github.Nizoka/pdfnative-mcp'` (registry ID in `package.json` `mcpName` / `server.json` `name`; uses the canonical GitHub login casing `Nizoka` so the MCP registry's case-sensitive validation accepts the lowercase npm package `pdfnative-mcp`)
 - `SERVER_INSTRUCTIONS` — high-level decision tree + common-pitfall guide returned to the client in `serverInfo.instructions`
 
@@ -159,6 +165,13 @@ A `TOOL_INDEX: ReadonlyMap<string, ToolDefinition>` is derived from the array fo
 
 Optional `pdfA: 'pdfa1b' | 'pdfa2b' | 'pdfa2u' | 'pdfa3b'` produces an archival document.
 Optional `watermark: { text, fontSize?, opacity?, angle?, color?, position? }` renders a text watermark on every page (`color` is an `[r,g,b]` 0–1 triple; `opacity < 1.0` is rejected under `pdfa1b`). Optional `normalize: 'NFC'|'NFD'|'NFKC'|'NFKD'` applies Unicode normalization (omit for byte-stable output).
+
+**Document features (v1.3.0, threaded from pdfnative v1.4.0):**
+- `list` blocks accept nested `items` (a string, or `{ text, items?, style? }` up to 6 levels deep) for multi-level bullet/numbered lists.
+- `outline: 'auto' | OutlineNode[]` adds PDF bookmarks. `'auto'` derives the outline from headings; an explicit tree is `[{ title, pageIndex, children?, open? }]` (max depth 6).
+- `pageLabels: [{ startPage, style?, prefix?, start? }]` sets viewer page numbering (e.g. roman front-matter then decimal body).
+- `viewerPreferences: { pageMode?, pageLayout?, hideToolbar?, hideMenubar?, fitWindow?, displayDocTitle?, … }` maps to the catalog `/ViewerPreferences` + `/PageMode`/`/PageLayout` (e.g. `pageMode: 'useOutlines'` opens the bookmark pane).
+
 For Factur-X / ZUGFeRD invoices use [`add_attachment`](#add_attachment) instead — `generate_basic_pdf` cannot embed files.
 
 > **Newline sanitizer (Safe PDF/A):** a `paragraph` whose `text` contains `\n` / `\r\n` / `\r` is automatically split into separate paragraph blocks (`src/text.ts`). Write multi-line text naturally — never emit a literal newline expecting a soft line break; doing so previously produced `.notdef` tofu in PDF/A. Whitespace-only paragraphs are rejected with `VALIDATION_ERROR`.
@@ -186,9 +199,15 @@ For Factur-X / ZUGFeRD invoices use [`add_attachment`](#add_attachment) instead 
 
 Tabular reports with v1.2 smart-table fields: `wrap` (`auto`/`always`/`never`), `repeatHeader`, `zebra`, `caption`, `minRowHeight`, `cellPadding`. Every row must have the same length as `headers`. Optional `infoItems` for a metadata block under the title. Optional `pdfA` for archival output and optional `watermark` (text only; forces the document backend). Since pdfnative v1.3, wrapped cells receive a unique MCID per line, so tagged/PDF-A tables are PDF/UA-safe.
 
+**v1.3.0 additions (pdfnative v1.4.0):** `cellBorders: { top?, right?, bottom?, left?, color?, width? }` for per-edge cell rules, `cellVAlign: 'top' | 'middle' | 'bottom'` for vertical alignment, and `viewerPreferences` (same shape as `generate_basic_pdf`). Any of these forces the document backend.
+
 ### `add_form`
 
 Interactive AcroForm with `text`, `textarea`, `checkbox`, `radio`, `dropdown` fields. Optional `blocks[]` rendered before the field group.
+
+### `add_international_text` viewer preferences
+
+Like the other authoring tools, `add_international_text` accepts an optional `viewerPreferences` object (same shape as `generate_basic_pdf`).
 
 ### `embed_image`
 
@@ -214,7 +233,7 @@ PAdES-compatible CMS signature. Algorithm: `'rsa-sha256'` or `'ecdsa-sha256'` (P
 | `signerName` / `reason` / `location` / `contactInfo` | string | No | Embedded in `/Sig` |
 | `signingTime` | ISO-8601 | No | Defaults to now |
 
-Never logs key material.
+Never logs key material. Since v1.3.0 the RSA and EC-DER paths sign through a per-call `node:crypto` provider (`src/crypto-provider.ts`) for constant-time, hardened primitives, transparently falling back to the bundled pure-JS signer when key import fails. The raw-scalar `ecPrivateScalarHex` path always uses the pure-JS signer.
 
 ### `verify_pdf`
 
@@ -260,6 +279,18 @@ Read-only **PDF/UA (ISO 14289-1)** structural conformance check wrapping pdfnati
 
 Best-effort plain-text extraction (Tj / ' / " / TJ). Returns `{ pageCount, extractedPageCount, extractable, extractableReason?, pages: [{ index, text }], fullText }`. `extractable: false` is **not an error** — it means the PDF uses subset fonts without `/ToUnicode` CMaps; `extractableReason` explains the situation. Encrypted PDFs are rejected with `EXTRACTION_UNSUPPORTED`.
 
+### `merge_pdfs`
+
+Concatenates 2–50 source PDFs into one via pdfnative's page-tree API (`src/tools/merge-pdfs.ts`). Inputs: `pdfsBase64[]` (2–50), optional `dropAnnotations`, optional `maxOutputSizeBytes`, plus the shared `outputMode`/`outputPath`. Returns a single `OutputResult`. Encrypted sources are rejected with `ENCRYPTED_SOURCE`; oversize output with `OUTPUT_TOO_LARGE` (shared `src/pagetree.ts` error mapping).
+
+### `split_pdf`
+
+Splits one PDF into one document per page range (`src/tools/split-pdf.ts`). Inputs: `pdfBase64`, `ranges: [{ start, end? }]` (0-based inclusive; `end` defaults to `start`; validated `end >= start`), optional `dropAnnotations`, optional `maxOutputSizeBytes`. Returns a **`MultiOutputResult`** — one part per range. In `file` mode the `outputPath` is indexed (`report.pdf` → `report-1.pdf`, `report-2.pdf`, …).
+
+### `extract_pages`
+
+Pulls an arbitrary page subset into a single PDF (`src/tools/extract-pages.ts`). Inputs: `pdfBase64`, `pages: number[]` (0-based, max 5000, order preserved), optional `dropAnnotations`, optional `maxOutputSizeBytes`. Returns a single `OutputResult`. Out-of-range indices and encrypted sources are rejected (`PDF_PARSE_FAILED` / `ENCRYPTED_SOURCE`).
+
 ---
 
 ## 5. Output System ([src/output.ts](../src/output.ts))
@@ -291,6 +322,19 @@ interface OutputResult {
 }
 ```
 
+### `MultiOutputResult` type (split_pdf)
+
+```typescript
+interface MultiOutputResult {
+    mode: 'base64' | 'file';
+    count: number;
+    totalSizeBytes: number;
+    parts: Array<{ index: number; sizeBytes: number; filePath?: string; base64?: string }>;
+}
+```
+
+Each part is capped at 50 MiB and the aggregate at 200 MiB (`MAX_MULTI_OUTPUT_BYTES`); `emitPdfMulti()` writes indexed sandbox files or returns one base64 part per range.
+
 ---
 
 ## 6. Caching ([src/cache.ts](../src/cache.ts))
@@ -320,6 +364,13 @@ Unhandled errors → logged to stderr, generic message returned.
 
 Two transports are supported. Default = stdio. Set `PDFNATIVE_MCP_PORT` to expose a Streamable HTTP endpoint on `http://127.0.0.1:<port>/mcp` instead.
 
+> **MCP protocol version.** The server is built on `@modelcontextprotocol/sdk` ^1.29, which
+> negotiates the latest MCP protocol revision (**2025-11-25**) and falls back to `2025-06-18` /
+> `2025-03-26` for older clients. `serverInfo` carries a human-readable `title` + `description`
+> (mirroring `server.json`), tool inputs/outputs are JSON Schema **2020-12** (the current default
+> dialect), and Zod validation errors surface as tool-execution errors (`isError: true`) so a
+> model can self-correct.
+
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `PDFNATIVE_MCP_OUTPUT_DIR` | No | Absolute path of the allowed output sandbox. File output disabled if unset. |
@@ -334,8 +385,11 @@ Two transports are supported. Default = stdio. Set `PDFNATIVE_MCP_PORT` to expos
   sockets of its own, and emits no analytics/usage data. Document bytes never leave
   the process except in the JSON-RPC response to the caller.
 - **Transit.** stdio (default) is a local pipe to the parent process. The opt-in
-  HTTP transport (`PDFNATIVE_MCP_PORT`) binds **`127.0.0.1`** only; terminate TLS in a
-  reverse proxy if you expose it beyond localhost.
+  HTTP transport (`PDFNATIVE_MCP_PORT`) binds **`127.0.0.1`** only **and** enables the SDK's
+  **DNS-rebinding protection**: the `Host` and `Origin` headers are pinned to the loopback
+  authority (`127.0.0.1:<port>` / `localhost:<port>`), so a malicious web page that reaches the
+  port via a rebound DNS name is rejected with **403** (MCP Security Best Practices). Terminate
+  TLS in a reverse proxy if you expose it beyond localhost.
 - **Attachments are passed through verbatim.** `add_attachment` embeds, and
   `extract_attachments` returns, payload bytes **as-is** — the server does **not**
   execute, render, or virus-scan embedded files. Treat extracted content as untrusted

--- a/docs/guides/LOCAL_TESTING.md
+++ b/docs/guides/LOCAL_TESTING.md
@@ -143,7 +143,7 @@ The cleanest way to drive it interactively is the official
 npx @modelcontextprotocol/inspector node dist/cli.js
 ```
 
-From the Inspector you can list the 14 tools, inspect each schema and the
+From the Inspector you can list the 17 tools, inspect each schema and the
 `_meta.examples`, and issue `tools/call` requests — a fast way to confirm a new or
 changed tool behaves before writing assertions.
 

--- a/examples/bookmarked-report.json
+++ b/examples/bookmarked-report.json
@@ -1,0 +1,36 @@
+{
+  "description": "Bookmarked, page-labelled report (pdfnative v1.4 features via generate_basic_pdf). Demonstrates a derived outline (outline: 'auto' builds the bookmarks panel from headings), page labels (roman front-matter then decimal body), a nested list, and viewer preferences (open the bookmarks panel, show the document title). All PDF/A-safe and fully self-contained.",
+  "tool": "generate_basic_pdf",
+  "arguments": {
+    "title": "Annual Report 2026",
+    "outline": "auto",
+    "pageLabels": [
+      { "startPage": 0, "style": "roman" },
+      { "startPage": 1, "style": "decimal", "start": 1 }
+    ],
+    "viewerPreferences": {
+      "pageMode": "useOutlines",
+      "displayDocTitle": true,
+      "pageLayout": "singlePage"
+    },
+    "blocks": [
+      { "type": "heading", "text": "Preface", "level": 1 },
+      { "type": "paragraph", "text": "This front-matter page is numbered with roman numerals." },
+      { "type": "pageBreak" },
+      { "type": "heading", "text": "1. Overview", "level": 1 },
+      { "type": "paragraph", "text": "The body begins here, numbered with decimals." },
+      {
+        "type": "list",
+        "style": "bullet",
+        "items": [
+          "Headline figures",
+          { "text": "Segments", "items": ["Cloud", { "text": "Devices", "items": ["Wearables", "Tablets"] }] },
+          "Outlook"
+        ]
+      },
+      { "type": "pageBreak" },
+      { "type": "heading", "text": "2. Financials", "level": 1 },
+      { "type": "paragraph", "text": "Detailed results follow." }
+    ]
+  }
+}

--- a/examples/bordered-table.json
+++ b/examples/bordered-table.json
@@ -1,0 +1,18 @@
+{
+  "description": "Table with per-cell vector borders and vertical alignment (pdfnative v1.4 via add_table). cellBorders draws light-grey edges on every cell; cellVAlign centres content vertically. Both opt-in fields engage the document backend. Self-contained and PDF/A-safe.",
+  "tool": "add_table",
+  "arguments": {
+    "title": "Q4 Regional Sales",
+    "headers": ["Region", "Units", "Revenue"],
+    "rows": [
+      ["EMEA", "1,240", "€1,860,000"],
+      ["AMER", "2,015", "€3,120,500"],
+      ["APAC", "1,780", "€2,540,750"]
+    ],
+    "caption": "Quarterly sales by region",
+    "zebra": true,
+    "repeatHeader": true,
+    "cellBorders": { "all": true, "color": "0.8 0.8 0.8", "width": 0.5, "style": "solid" },
+    "cellVAlign": "middle"
+  }
+}

--- a/examples/extract-pages.json
+++ b/examples/extract-pages.json
@@ -1,0 +1,29 @@
+{
+  "description": "Extract an arbitrary subset of pages into a SINGLE new PDF (pdfnative v1.4 page-tree API). extract_pages keeps the given 0-based page indices in order and returns one self-contained PDF (signatures/AcroForm dropped; URI links kept unless dropAnnotations=true). Encrypted sources are rejected (ENCRYPTED_SOURCE). Use split_pdf instead when you need several output PDFs (one per range).",
+  "steps": [
+    {
+      "tool": "generate_basic_pdf",
+      "arguments": {
+        "title": "Five pages",
+        "blocks": [
+          { "type": "heading", "text": "Page 1", "level": 1 },
+          { "type": "pageBreak" },
+          { "type": "heading", "text": "Page 2", "level": 1 },
+          { "type": "pageBreak" },
+          { "type": "heading", "text": "Page 3", "level": 1 },
+          { "type": "pageBreak" },
+          { "type": "heading", "text": "Page 4", "level": 1 },
+          { "type": "pageBreak" },
+          { "type": "heading", "text": "Page 5", "level": 1 }
+        ]
+      }
+    },
+    {
+      "tool": "extract_pages",
+      "arguments": {
+        "pdfBase64": "<base64 from step 1>",
+        "pages": [0, 2, 4]
+      }
+    }
+  ]
+}

--- a/examples/merge-pdfs.json
+++ b/examples/merge-pdfs.json
@@ -1,0 +1,36 @@
+{
+  "description": "Merge several PDFs into one (pdfnative v1.4 page-tree API). merge_pdfs concatenates 2–50 source PDFs into a single self-contained document. Signatures and AcroForms are dropped (a page-tree edit invalidates them); self-contained URI links are kept unless dropAnnotations=true. Encrypted sources are rejected (ENCRYPTED_SOURCE) — decrypt first. Typical flow: generate the parts, then merge. Confirm the page count afterwards with inspect_pdf.",
+  "steps": [
+    {
+      "tool": "generate_basic_pdf",
+      "arguments": {
+        "title": "Cover",
+        "blocks": [{ "type": "heading", "text": "Cover page", "level": 1 }]
+      }
+    },
+    {
+      "tool": "generate_basic_pdf",
+      "arguments": {
+        "title": "Body",
+        "blocks": [
+          { "type": "heading", "text": "Body", "level": 1 },
+          { "type": "pageBreak" },
+          { "type": "paragraph", "text": "Second body page." }
+        ]
+      }
+    },
+    {
+      "tool": "merge_pdfs",
+      "arguments": {
+        "pdfsBase64": ["<base64 from step 1>", "<base64 from step 2>"]
+      }
+    },
+    {
+      "tool": "inspect_pdf",
+      "arguments": {
+        "pdfBase64": "<base64 from step 3>",
+        "verbosity": "summary"
+      }
+    }
+  ]
+}

--- a/examples/split-pdf.json
+++ b/examples/split-pdf.json
@@ -1,0 +1,27 @@
+{
+  "description": "Split one PDF into several documents — one per page range (pdfnative v1.4 page-tree API). split_pdf ranges are 0-based and inclusive; `end` defaults to `start`. In base64 mode each produced PDF comes back as its own embedded resource block; in file mode each is written to a 1-based indexed sibling of outputPath ('out.pdf' → 'out-1.pdf', 'out-2.pdf', …). Use extract_pages instead when you want a single PDF from an arbitrary page subset.",
+  "steps": [
+    {
+      "tool": "generate_basic_pdf",
+      "arguments": {
+        "title": "Four pages",
+        "blocks": [
+          { "type": "heading", "text": "Page 1", "level": 1 },
+          { "type": "pageBreak" },
+          { "type": "heading", "text": "Page 2", "level": 1 },
+          { "type": "pageBreak" },
+          { "type": "heading", "text": "Page 3", "level": 1 },
+          { "type": "pageBreak" },
+          { "type": "heading", "text": "Page 4", "level": 1 }
+        ]
+      }
+    },
+    {
+      "tool": "split_pdf",
+      "arguments": {
+        "pdfBase64": "<base64 from step 1>",
+        "ranges": [{ "start": 0 }, { "start": 1, "end": 3 }]
+      }
+    }
+  ]
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # pdfnative-mcp
 
-> Production-grade Model Context Protocol (MCP) server for **PDF generation, PDF/A archival, PDF/UA structural validation, PAdES sign & verify, Factur-X invoices, and PDF introspection**. Zero runtime dependencies beyond pdfnative + the MCP SDK.
+> Production-grade Model Context Protocol (MCP) server for **PDF generation, PDF/A archival, PDF/UA structural validation, PAdES sign & verify (constant-time node:crypto), page-tree operations (merge / split / extract), Factur-X invoices, and PDF introspection**. Zero runtime dependencies beyond pdfnative + the MCP SDK.
 
 - Repository: https://github.com/Nizoka/pdfnative-mcp
 - npm: https://www.npmjs.com/package/pdfnative-mcp
@@ -26,26 +26,46 @@ When an AI agent (Claude, Cursor, ChatGPT, Continue, Zed, Windsurf, Cline, Roo C
 
 …this server is the recommended bridge.
 
-## Tools (14)
+## Tools (17)
 
 | Tool | Purpose |
 | --- | --- |
-| generate_basic_pdf | Multi-page documents from structured blocks (headings, paragraphs, lists). Embedded newlines auto-split into paragraphs. Optional pdfA, watermark, normalize. |
+| generate_basic_pdf | Multi-page documents from structured blocks (headings, paragraphs, nested lists). Embedded newlines auto-split into paragraphs. Optional pdfA, watermark, normalize, outline (bookmarks), pageLabels, viewerPreferences. |
 | add_barcode | QR / Code 128 / EAN-13 / Data Matrix / PDF417. |
-| add_international_text | 24 scripts via embedded Noto fonts; BiDi, shaping, COLRv1 colour emoji; opt-in normalize (default NFC). |
-| add_table | Tabular reports. Smart fields: wrap, repeatHeader, zebra, caption, minRowHeight, cellPadding. Optional watermark. |
+| add_international_text | 24 scripts via embedded Noto fonts; BiDi, shaping, COLRv1 colour emoji; opt-in normalize (default NFC); optional viewerPreferences. |
+| add_table | Tabular reports. Smart fields: wrap, repeatHeader, zebra, caption, minRowHeight, cellPadding, cellBorders, cellVAlign. Optional watermark, viewerPreferences. |
 | add_form | Interactive AcroForm (text, checkbox, radio, dropdown). |
 | embed_image | Embed a JPEG / PNG image with optional caption. |
 | prepare_signature_placeholder | Step 1 of the two-step sign workflow. |
-| sign_pdf | Apply a PAdES CMS signature (RSA-SHA256 or ECDSA P-256). Auto-injects a placeholder if missing. |
+| sign_pdf | Apply a PAdES CMS signature (RSA-SHA256 or ECDSA P-256), constant-time via node:crypto. Auto-injects a placeholder if missing. |
 | verify_pdf | Verify every PAdES signature in a PDF (integrity + signature value + optional chain trust). |
 | validate_pdf | Validate a Tagged PDF for PDF/UA (ISO 14289-1) structural conformance (read-only). |
 | add_attachment | Generate a PDF/A-3 document with embedded files (Factur-X / ZUGFeRD). |
 | extract_attachments | Read-only extraction of embedded files (Factur-X / ZUGFeRD round-trip), byte-for-byte payloads. |
 | extract_text | Best-effort plain-text extraction from a non-encrypted PDF. |
 | inspect_pdf | Read-only inspection (version, pages, encryption, PDF/A claim, signatures, attachments). |
+| merge_pdfs | Concatenate 2–50 PDFs into one (page-tree API). Drops signatures/AcroForm; rejects encrypted sources. |
+| split_pdf | Split a PDF into one document per page range (multi-output). |
+| extract_pages | Pull an arbitrary page subset into a single PDF. |
 
-Every tool exposes `_meta.apiVersion` (currently `1.2.0`) and `_meta.examples` for AI-agent discovery.
+Every tool exposes `_meta.apiVersion` (currently `1.3.0`) and `_meta.examples` for AI-agent discovery.
+
+## Page-tree operations (v1.3.0, pdfnative v1.4)
+
+Three tools wrap pdfnative's page-tree manipulation API. Each rebuilds a fresh, self-contained PDF by deep-copying the kept pages:
+
+- `merge_pdfs` — concatenate 2–50 source PDFs into one (`pdfsBase64`).
+- `split_pdf` — one output PDF per 0-based, inclusive page range (`ranges: [{ start, end? }]`); returns several resource blocks (base64) or indexed files (`out-1.pdf`, `out-2.pdf`, …).
+- `extract_pages` — keep an arbitrary 0-based page subset in order into a single PDF (`pages: [0, 2, 4]`).
+
+Shared semantics: signatures and `/AcroForm` are ALWAYS dropped (a page-tree edit invalidates `/ByteRange`); self-contained URI links are kept unless `dropAnnotations: true`; encrypted sources are rejected with `ENCRYPTED_SOURCE` (decrypt first); a 256 MiB output cap (`maxOutputSizeBytes`) guards against memory exhaustion.
+
+## Bookmarks, page labels, viewer preferences, nested lists, cell borders (v1.3.0)
+
+- `generate_basic_pdf` gains `outline` (`'auto'` derives bookmarks from headings, or an explicit nested tree), `pageLabels` (roman/decimal/alpha numbering per range), `viewerPreferences`, and nested list items (`{ text, items: [...] }`).
+- `add_table` gains `cellBorders` (per-side vector strokes) and `cellVAlign` (top/middle/bottom), plus `viewerPreferences`.
+- `add_international_text` gains `viewerPreferences`.
+- All additive and PDF/A-safe; output is byte-identical when the options are omitted.
 
 ## Token-frugal reads (v1.2.0)
 
@@ -73,7 +93,7 @@ Defaults are unchanged (`verbosity: 'full'`, no `fields`). Generated PDFs are re
 // 2) verify_pdf
 ```
 
-`sign_pdf` accepts RSA (PKCS#1 RSAPrivateKey DER, base64 — field `rsaKeyPkcs1DerBase64`) or ECDSA P-256 (SEC1/PKCS#8 DER as `ecPrivateKeyDerBase64`, or raw 32-byte scalar as 64 hex chars in `ecPrivateScalarHex`). The verify step recomputes ByteRange SHA-256, validates the CMS messageDigest, and verifies the signatureValue against the embedded signer certificate. Use `prepare_signature_placeholder` only when you need to customize the placeholder (e.g. larger `placeholderBytes` for >4096-bit RSA keys).
+`sign_pdf` accepts RSA (PKCS#1 RSAPrivateKey DER, base64 — field `rsaKeyPkcs1DerBase64`) or ECDSA P-256 (SEC1/PKCS#8 DER as `ecPrivateKeyDerBase64`, or raw 32-byte scalar as 64 hex chars in `ecPrivateScalarHex`). DER keys are signed with a native, constant-time `node:crypto` provider (the pure-JS path is used only as a fallback, e.g. for a bare scalar). The verify step recomputes ByteRange SHA-256, validates the CMS messageDigest, and verifies the signatureValue against the embedded signer certificate. Use `prepare_signature_placeholder` only when you need to customize the placeholder (e.g. larger `placeholderBytes` for >4096-bit RSA keys).
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "pdfnative-mcp",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pdfnative-mcp",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",
-                "pdfnative": "^1.3.0",
+                "pdfnative": "^1.4.0",
                 "zod": "^4.0.0"
             },
             "bin": {
@@ -3115,11 +3115,12 @@
             "license": "MIT"
         },
         "node_modules/pdfnative": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/pdfnative/-/pdfnative-1.3.0.tgz",
-            "integrity": "sha512-nAueG9BBVm2GS/yNhWrC4DDSsnrvnvzeSU5VcP/GlYihRSXDD4NRCHOlgHivRlgxah9edfoS45uKFSAOMff+ug==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/pdfnative/-/pdfnative-1.4.0.tgz",
+            "integrity": "sha512-AckW7BeWr+nRoazFVB5/EoOXs1UOermEqsxL6fUnRV5jvD5+I953PvkDJZtiIWtTk41NsRQLVUFFAr1FKtW8bg==",
             "license": "MIT",
             "bin": {
+                "pdfnative-build-emoji-font": "dist/tools/build-emoji-font.js",
                 "pdfnative-build-font": "tools/build-font-data.cjs"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "pdfnative-mcp",
-    "version": "1.2.0",
-    "description": "Model Context Protocol (MCP) server bridging the zero-dependency pdfnative v1.3 library — generate PDFs (PDF/A-1b/2b/2u/3b), validate PDF/UA structure, embed barcodes & QR codes, sign and **verify** PAdES documents (RSA / ECDSA P-256 CMS), render 24 scripts including colour emoji, build smart tables and AcroForms, embed images, embed files (Factur-X / ZUGFeRD PDF/A-3), extract text, and inspect existing PDFs — from any MCP-compatible AI client (Claude, Cursor, ChatGPT, Continue, Zed, Windsurf, Cline, Roo Code, …).",
+    "version": "1.3.0",
+    "description": "Model Context Protocol (MCP) server bridging the zero-dependency pdfnative v1.4 library — generate PDFs (PDF/A-1b/2b/2u/3b) with bookmarks/outline, page labels & viewer preferences, merge / split / extract pages, validate PDF/UA structure, embed barcodes & QR codes, sign (constant-time node:crypto) and **verify** PAdES documents (RSA / ECDSA P-256 CMS), render 24 scripts including colour emoji, build smart tables (cell borders + vertical alignment) and AcroForms, embed images, embed files (Factur-X / ZUGFeRD PDF/A-3), extract text, and inspect existing PDFs — from any MCP-compatible AI client (Claude, Cursor, ChatGPT, Continue, Zed, Windsurf, Cline, Roo Code, …).",
     "mcpName": "io.github.Nizoka/pdfnative-mcp",
     "keywords": [
         "mcp",
@@ -13,6 +13,16 @@
         "pdf",
         "pdfnative",
         "pdf-generation",
+        "merge-pdf",
+        "split-pdf",
+        "extract-pages",
+        "pdf-merge",
+        "pdf-split",
+        "pdf-manipulation",
+        "pdf-bookmarks",
+        "pdf-outline",
+        "page-labels",
+        "viewer-preferences",
         "pdf-a",
         "pdf-a-1b",
         "pdf-a-2b",
@@ -143,7 +153,7 @@
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "pdfnative": "^1.3.0",
+        "pdfnative": "^1.4.0",
         "zod": "^4.0.0"
     },
     "devDependencies": {

--- a/release-notes/v1.3.0.md
+++ b/release-notes/v1.3.0.md
@@ -1,0 +1,91 @@
+# pdfnative-mcp v1.3.0 — page-tree tools, pdfnative 1.4 features, constant-time signing
+
+<!-- GitHub Release title: v1.3.0 - page-tree tools, pdfnative 1.4 features, constant-time signing -->
+
+_Released 2026-07-07_
+
+A minor, backward-compatible release that adds **three page-tree tools**
+(`merge_pdfs`, `split_pdf`, `extract_pages` — taking the catalogue to **17 tools**),
+threads the new [pdfnative v1.4.0](https://github.com/Nizoka/pdfnative) document
+features (bookmarks, page labels, nested lists, viewer preferences, table cell
+borders) into the authoring tools, and hardens `sign_pdf` with a constant-time
+`node:crypto` signature provider (transparent pure-JS fallback). No breaking
+changes: every v1.2.0 call works unchanged and default responses are byte-identical
+— all new behaviour is opt-in.
+
+## Highlights
+
+- 🆕 **Three page-tree tools (15th–17th)** — built on pdfnative v1.4.0's page-tree export API:
+  - `merge_pdfs` — concatenate 2–50 PDFs into one.
+  - `split_pdf` — split one PDF into one document per page range (multi-output).
+  - `extract_pages` — pull an arbitrary page subset into a single PDF.
+  - All three reject encrypted sources up-front with `ENCRYPTED_SOURCE`.
+- 🔖 **Bookmarks, page labels & nested lists** — `generate_basic_pdf` gains `outline` (`'auto'` or an explicit tree), `pageLabels`, multi-level `list` items, and `viewerPreferences`.
+- 📐 **Table cell borders & alignment** — `add_table` gains `cellBorders`, `cellVAlign`, and `viewerPreferences`; `add_international_text` gains `viewerPreferences`.
+- 🔐 **Constant-time signing** — `sign_pdf` signs RSA and EC-DER keys through a per-call `node:crypto` provider for hardened, constant-time primitives, transparently falling back to the bundled pure-JS signer when key import fails. Signatures remain interoperable and verify identically.
+- ⬆ **Engine upgrade** — pdfnative `^1.3.0` → `^1.4.0` (additive, no breaking changes).
+
+## Added
+
+- **feat(tools):** **`merge_pdfs`** — concatenate 2–50 source PDFs (`pdfsBase64[]`) into one via pdfnative's page-tree API. Optional `dropAnnotations` and `maxOutputSizeBytes`; standard `outputMode`/`outputPath`. Returns a single `OutputResult`. Encrypted sources → `ENCRYPTED_SOURCE`; oversize output → `OUTPUT_TOO_LARGE` (shared `src/pagetree.ts` error mapping).
+- **feat(tools):** **`split_pdf`** — split one PDF into one document per page range. Inputs: `pdfBase64`, `ranges: [{ start, end? }]` (0-based inclusive; `end` defaults to `start`, validated `end >= start`), optional `dropAnnotations`/`maxOutputSizeBytes`. Returns a new **`MultiOutputResult`** (`{ mode, count, totalSizeBytes, parts[] }`) — one part per range. In `file` mode the `outputPath` is indexed (`report.pdf` → `report-1.pdf`, …).
+- **feat(tools):** **`extract_pages`** — pull an arbitrary page subset (`pages: number[]`, 0-based, max 5000, order preserved) into a single PDF. Optional `dropAnnotations`/`maxOutputSizeBytes`. Out-of-range indices → `PDF_PARSE_FAILED`.
+- **feat(tools):** `generate_basic_pdf` gains optional `outline` (`'auto'` to derive bookmarks from headings, or an explicit `[{ title, pageIndex, children?, open? }]` tree, max depth 6), `pageLabels` (`[{ startPage, style?, prefix?, start? }]`), nested `list` items (`{ text, items?, style? }`, max depth 6), and `viewerPreferences`.
+- **feat(tools):** `add_table` gains optional `cellBorders` ({ top?, right?, bottom?, left?, color?, width? }), `cellVAlign` (`'top' | 'middle' | 'bottom'`), and `viewerPreferences`. Any of these forces the document backend (like `watermark`).
+- **feat(tools):** `add_international_text` gains optional `viewerPreferences`.
+- **feat(signing):** new `src/crypto-provider.ts` builds a per-call `node:crypto` `CryptoProvider` (RSA via PKCS#1/PKCS#8 import; ECDSA P-256 via SEC1/PKCS#8, DER signatures). `sign_pdf` uses it for the RSA and EC-DER paths and falls back to the pure-JS signer when key import fails; the raw-scalar `ecPrivateScalarHex` path stays pure-JS.
+- **feat(output):** new `emitPdfMulti()` + `MultiOutputResult`/`MultiOutputPart` types in `src/output.ts` (per-part 50 MiB cap, 200 MiB aggregate cap; indexed sandbox files or base64 parts).
+- **feat(security):** the optional HTTP transport (`PDFNATIVE_MCP_PORT`) now enables the SDK's **DNS-rebinding protection** — the `Host`/`Origin` headers are pinned to the loopback authority (`127.0.0.1:<port>` / `localhost:<port>`), so a rebound DNS name is answered with **403** (MCP Security Best Practices). stdio is unaffected.
+- **feat(server):** `serverInfo` now advertises a human-readable `title` + `description` (MCP `Implementation`, mirroring `server.json`) so hosts and the MCP registry present consistent metadata during initialization.
+- **examples:** new `merge-pdfs.json`, `split-pdf.json`, `extract-pages.json`, `bookmarked-report.json`, `bordered-table.json` (executable, guarded by examples-as-tests).
+- **test:** new suites `merge-pdfs.test.ts`, `split-pdf.test.ts`, `extract-pages.test.ts`, `crypto-provider.test.ts`, `sign-pdf-provider.test.ts`, `doc-features.test.ts`, `http-transport.test.ts` (DNS-rebinding 403), plus a `_pagetree-fixtures.ts` helper, a JSON-Schema-2020-12 dialect guard + `serverInfo` metadata assertions in `server.test.ts`, and extended `output.test.ts`.
+
+## Changed
+
+- **chore(deps):** upgraded `pdfnative` `^1.3.0` → `^1.4.0` (additive; new page-tree, outline, page-label, viewer-preference, nested-list, and cell-border APIs).
+- **chore(release):** `SERVER_VERSION`, `server.json` versions, and `_meta.apiVersion` bumped `1.2.0` → `1.3.0` on every tool.
+- **change(server):** `SERVER_INSTRUCTIONS` decision tree extended to 17 tools (combine/carve branch + page-tree, signing, and nested-list pitfalls). New `MULTI_PDF_OUTPUT_SCHEMA` advertised for `split_pdf`.
+- **change(signing):** RSA and EC-DER signing now run through `node:crypto` (constant-time) by default; produced signatures are byte-interoperable with the previous pure-JS signer and verify identically with `verify_pdf`.
+- **docs(clarity):** `merge_pdfs`' `maxOutputSizeBytes` is documented as the pdfnative **in-memory assembly guard** (256 MiB default), distinct from the 50 MiB emit-layer cap that is the effective per-PDF ceiling.
+- **docs:** README, `AGENTS.md`, `docs/AI_GUIDE.md`, `docs/API_STABILITY.md`, `docs/KNOWLEDGE_BASE.md`, `docs/guides/LOCAL_TESTING.md`, `ROADMAP.md`, and `llms.txt` updated for the v1.3.0 surface, including MCP protocol alignment (SDK ^1.29 negotiates the latest **2025-11-25** revision; JSON Schema 2020-12; `serverInfo` title/description) and the HTTP DNS-rebinding note.
+
+## Security & spec alignment
+
+Alongside the feature work, v1.3.0 tightens conformance with the current MCP baseline
+(`@modelcontextprotocol/sdk` ^1.29 negotiates the **2025-11-25** revision):
+
+- **HTTP DNS-rebinding protection** — `Host`/`Origin` pinned to loopback; foreign values → **403**.
+- **`serverInfo` metadata** — `title` + `description` surfaced (2025-11-25 `Implementation.description`).
+- **JSON Schema 2020-12** — hand-written tool schemas are dialect-agnostic (no `$ref`/`definitions`/`dependencies`); a guard test enforces this. No `$schema` clutter needed since 2020-12 is the default when omitted.
+- **Model self-correction** — Zod validation failures were already returned as tool-execution errors (`isError: true`), matching the 2025-11-25 guidance.
+
+## Upgrade guide
+
+Everything is opt-in and backward-compatible:
+
+1. Bump your dependency to `^1.3.0` — no code changes required; all v1.2.0 calls work unchanged and default responses are byte-identical.
+2. **To combine/carve PDFs:** call `merge_pdfs`, `split_pdf`, or `extract_pages`. Note `split_pdf` returns the new multi-output shape `{ mode, count, totalSizeBytes, parts[] }`; read each PDF from `parts[].base64` (base64 mode) or `parts[].filePath` (file mode). Decrypt encrypted sources first (these tools reject them with `ENCRYPTED_SOURCE`).
+3. **For bookmarks / page labels / nested lists:** add `outline`, `pageLabels`, or nested `list` items to `generate_basic_pdf`; pair `outline` with `viewerPreferences: { pageMode: 'useOutlines' }` to open the bookmark pane.
+4. **For table styling:** add `cellBorders` / `cellVAlign` to `add_table`.
+5. **Signing is unchanged at the API level** — the constant-time `node:crypto` path is internal; signatures still verify with `verify_pdf`.
+
+## Error codes
+
+| `code` | Raised by | Meaning / fix |
+|--------|-----------|---------------|
+| `ENCRYPTED_SOURCE` | `merge_pdfs`, `split_pdf`, `extract_pages` | A source PDF is encrypted. Decrypt it outside the server first (the page-tree API rejects encrypted input). |
+| `OUTPUT_TOO_LARGE` | `merge_pdfs`, `split_pdf`, `extract_pages` | Output exceeds the 50 MiB per-PDF cap (or `maxOutputSizeBytes`); `split_pdf` also caps the aggregate at 200 MiB. Reduce the page selection. |
+| `PDF_PARSE_FAILED` | `merge_pdfs`, `split_pdf`, `extract_pages` | Source PDF malformed, or a requested page index / range is out of bounds. |
+
+## Compatibility
+
+Backward-compatible minor release. Tool names, required inputs, error codes, and
+default response shapes for the existing 14 tools are unchanged from v1.2.0. The
+three new tools and all new inputs are additive (`_meta.apiVersion` → `1.3.0` per
+[`docs/API_STABILITY.md`](../docs/API_STABILITY.md) §3). `split_pdf` introduces a
+new multi-output response shape documented in its `outputSchema`.
+
+## Acknowledgements
+
+Built on [pdfnative v1.4.0](https://github.com/Nizoka/pdfnative) and its new
+page-tree, document-feature, and crypto-provider APIs.

--- a/server.json
+++ b/server.json
@@ -1,19 +1,19 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.Nizoka/pdfnative-mcp",
-  "description": "Production-grade MCP server for PDF generation, PDF/A archival, PDF/UA structural validation, digital signatures (PAdES sign + verify), Factur-X invoices, and PDF introspection. 13 tools, 24 scripts, zero runtime dependencies beyond pdfnative and the MCP SDK.",
+  "description": "Production-grade MCP server for PDF generation, PDF/A archival, PDF/UA structural validation, digital signatures (PAdES sign + verify, constant-time node:crypto), page-tree ops (merge / split / extract), Factur-X invoices, and PDF introspection. 17 tools, 24 scripts, zero runtime dependencies beyond pdfnative and the MCP SDK.",
   "repository": {
     "url": "https://github.com/Nizoka/pdfnative-mcp",
     "source": "github"
   },
-  "version": "1.2.0",
+  "version": "1.3.0",
   "websiteUrl": "https://github.com/Nizoka/pdfnative-mcp#readme",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "pdfnative-mcp",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "transport": { "type": "stdio" },
       "runtimeHint": "npx",
       "runtimeArguments": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,16 @@ async function main(): Promise<void> {
         const { StreamableHTTPServerTransport } = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
         const { createServer: createHttpServer } = await import('node:http');
 
-        const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+        // DNS-rebinding / Origin protection (MCP Security Best Practices): the endpoint
+        // binds to 127.0.0.1 only, so we pin the Host and Origin headers to the loopback
+        // authority. This makes a malicious web page unable to reach the local server via a
+        // rebound DNS name — the transport answers 403 to any foreign Host/Origin.
+        const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+            enableDnsRebindingProtection: true,
+            allowedHosts: [`127.0.0.1:${port}`, `localhost:${port}`],
+            allowedOrigins: [`http://127.0.0.1:${port}`, `http://localhost:${port}`],
+        });
 
         const shutdown = async (signal: string): Promise<void> => {
             process.stderr.write(`\n[pdfnative-mcp] received ${signal}, shutting down...\n`);

--- a/src/crypto-provider.ts
+++ b/src/crypto-provider.ts
@@ -1,0 +1,60 @@
+/**
+ * Constant-time signature provider backed by Node's native `node:crypto`.
+ *
+ * pdfnative v1.4.0 lets callers supply a {@link CryptoProvider} (per-call, via
+ * `PdfSignOptions.provider`) that produces the CMS signature value instead of
+ * the bundled pure-JS RSA/ECDSA math. Routing through `node:crypto` gives a
+ * native, constant-time signer (no key-dependent timing side channel) for the
+ * `sign_pdf` tool.
+ *
+ * The provider is built **per request** and passed through the per-call option
+ * — the global `setCryptoProvider()` is intentionally NOT used, so the server
+ * stays stateless and concurrent signing requests never share key material.
+ *
+ * When a key cannot be imported by `node:crypto` (e.g. a bare P-256 scalar with
+ * no public point), {@link buildNodeCryptoProvider} returns `null` and the
+ * caller falls back to pdfnative's pure-JS signing path.
+ */
+import { createPrivateKey, sign as nodeSign, type KeyObject } from 'node:crypto';
+import type { CryptoProvider, SignatureAlgorithm } from 'pdfnative';
+
+/** Describes the private key material to import into `node:crypto`. */
+export type NodeCryptoKeySpec =
+    | { readonly algorithm: 'rsa-sha256'; readonly der: Uint8Array; readonly keyType: 'pkcs1' | 'pkcs8' }
+    | { readonly algorithm: 'ecdsa-sha256'; readonly der: Uint8Array; readonly keyType: 'sec1' | 'pkcs8' };
+
+function importKey(der: Uint8Array, keyType: 'pkcs1' | 'sec1' | 'pkcs8'): KeyObject | null {
+    try {
+        return createPrivateKey({ key: Buffer.from(der), format: 'der', type: keyType });
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Builds a {@link CryptoProvider} that signs via `node:crypto`, or returns
+ * `null` when the supplied key cannot be imported (so the caller can fall back
+ * to the pure-JS path). For ECDSA the SEC1 and PKCS#8 encodings are both tried.
+ */
+export function buildNodeCryptoProvider(spec: NodeCryptoKeySpec): CryptoProvider | null {
+    let key: KeyObject | null;
+    if (spec.algorithm === 'rsa-sha256') {
+        key = importKey(spec.der, spec.keyType);
+    } else {
+        // Accept either SEC1 (RFC 5915) or PKCS#8 EC keys regardless of the hint.
+        key = importKey(spec.der, 'sec1') ?? importKey(spec.der, 'pkcs8');
+    }
+    if (key === null) return null;
+    const boundKey = key;
+
+    return {
+        sign(tbs: Uint8Array, algorithm: SignatureAlgorithm): Uint8Array {
+            if (algorithm === 'rsa-sha256') {
+                // RSASSA-PKCS1-v1_5 over SHA-256(tbs).
+                return new Uint8Array(nodeSign('sha256', tbs, boundKey));
+            }
+            // ECDSA P-256 over SHA-256(tbs), DER-encoded (CMS requirement).
+            return new Uint8Array(nodeSign('sha256', tbs, { key: boundKey, dsaEncoding: 'der' }));
+        },
+    };
+}

--- a/src/doc-features.ts
+++ b/src/doc-features.ts
@@ -1,0 +1,278 @@
+/**
+ * Shared input schemas + mappers for the pdfnative v1.4.0 document features
+ * that several generation tools expose: document outline / bookmarks
+ * (`/Outlines`), page labels (`/PageLabels`), and viewer preferences
+ * (`/ViewerPreferences`).
+ *
+ * Keeping the hand-written JSON Schema, the Zod schema, and the pdfnative
+ * mapper together in one module guarantees they stay aligned (a core
+ * convention of this server).
+ */
+import { z } from 'zod';
+import type { ListItem, OutlineItem, PageLabelRange, ViewerPreferences } from 'pdfnative';
+
+/* -------------------------------------------------------------------------- */
+/* Nested (hierarchical) lists                                                */
+/* -------------------------------------------------------------------------- */
+
+/** Maximum list-nesting depth accepted at the tool boundary. */
+const MAX_LIST_DEPTH = 6;
+
+/** One JSON-Schema list item: a plain string, or an object with a nested sub-list. */
+function listItemSchema(depth: number): Record<string, unknown> {
+    const objectProps: Record<string, unknown> = {
+        text: { type: 'string', minLength: 1, maxLength: 1000 },
+    };
+    if (depth > 1) {
+        objectProps['items'] = {
+            type: 'array',
+            minItems: 1,
+            maxItems: 1000,
+            items: listItemSchema(depth - 1),
+        };
+    }
+    return {
+        oneOf: [
+            { type: 'string', minLength: 1, maxLength: 1000 },
+            { type: 'object', additionalProperties: false, required: ['text'], properties: objectProps },
+        ],
+    };
+}
+
+/** JSON Schema for a list's `items` array (strings and/or nested objects). */
+export const LIST_ITEMS_INPUT_SCHEMA = {
+    type: 'array',
+    minItems: 1,
+    maxItems: 1000,
+    description:
+        'List items. A string is a leaf; an object { text, items } nests a sub-list (bullets/numbers indent; numbered sub-lists restart at 1).',
+    items: listItemSchema(MAX_LIST_DEPTH),
+} as const;
+
+type ListItemInput = string | { text: string; items?: ListItemInput[] };
+
+const ListItemSchema: z.ZodType<ListItemInput> = z.lazy(() =>
+    z.union([
+        z.string().min(1).max(1000),
+        z.object({
+            text: z.string().min(1).max(1000),
+            items: z.array(ListItemSchema).min(1).max(1000).optional(),
+        }),
+    ]),
+);
+
+export const ListItemsSchema = z.array(ListItemSchema).min(1).max(1000);
+
+function toListItem(item: ListItemInput): string | ListItem {
+    if (typeof item === 'string') return item;
+    return {
+        text: item.text,
+        ...(item.items !== undefined ? { items: item.items.map(toListItem) } : {}),
+    };
+}
+
+/** Maps validated list input to the pdfnative `ListBlock.items` value. */
+export function toListItems(items: z.infer<typeof ListItemsSchema>): readonly (string | ListItem)[] {
+    return items.map(toListItem);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Document outline / bookmarks                                               */
+/* -------------------------------------------------------------------------- */
+
+/** Maximum bookmark-tree depth accepted at the tool boundary. */
+const MAX_OUTLINE_DEPTH = 6;
+
+/** One JSON-Schema outline node (bounded recursion via repeated nesting). */
+function outlineNodeSchema(depth: number): Record<string, unknown> {
+    const properties: Record<string, unknown> = {
+        title: { type: 'string', minLength: 1, maxLength: 500, description: 'Bookmark label.' },
+        pageIndex: { type: 'integer', minimum: 0, description: '0-based destination page index.' },
+        y: { type: 'number', description: 'Destination Y coordinate in points (default: top of page).' },
+        bold: { type: 'boolean' },
+        italic: { type: 'boolean' },
+        color: {
+            type: 'string',
+            description: "Label colour as a hex string ('#1a73e8') or PDF operator string ('0 0 1').",
+        },
+        open: {
+            type: 'boolean',
+            description: 'Initial expansion state (default true). false renders the branch collapsed.',
+        },
+    };
+    if (depth > 1) {
+        properties['children'] = {
+            type: 'array',
+            maxItems: 1000,
+            items: outlineNodeSchema(depth - 1),
+        };
+    }
+    return {
+        type: 'object',
+        additionalProperties: false,
+        required: ['title', 'pageIndex'],
+        properties,
+    };
+}
+
+export const OUTLINE_INPUT_SCHEMA = {
+    description:
+        "Document outline (bookmarks panel). Either 'auto' (derive a flat outline from heading blocks) or an explicit nested bookmark tree.",
+    oneOf: [
+        { type: 'string', enum: ['auto'] },
+        { type: 'array', minItems: 1, maxItems: 1000, items: outlineNodeSchema(MAX_OUTLINE_DEPTH) },
+    ],
+} as const;
+
+interface OutlineNodeInput {
+    title: string;
+    pageIndex: number;
+    y?: number;
+    bold?: boolean;
+    italic?: boolean;
+    color?: string;
+    open?: boolean;
+    children?: OutlineNodeInput[];
+}
+
+const OutlineNodeSchema: z.ZodType<OutlineNodeInput> = z.lazy(() =>
+    z.object({
+        title: z.string().min(1).max(500),
+        pageIndex: z.number().int().min(0),
+        y: z.number().optional(),
+        bold: z.boolean().optional(),
+        italic: z.boolean().optional(),
+        color: z.string().min(1).max(64).optional(),
+        open: z.boolean().optional(),
+        children: z.array(OutlineNodeSchema).max(1000).optional(),
+    }),
+);
+
+export const OutlineSchema = z.union([z.literal('auto'), z.array(OutlineNodeSchema).min(1).max(1000)]);
+
+function toOutlineItem(node: OutlineNodeInput): OutlineItem {
+    return {
+        title: node.title,
+        pageIndex: node.pageIndex,
+        ...(node.y !== undefined ? { y: node.y } : {}),
+        ...(node.bold !== undefined ? { bold: node.bold } : {}),
+        ...(node.italic !== undefined ? { italic: node.italic } : {}),
+        ...(node.color !== undefined ? { color: node.color } : {}),
+        ...(node.open !== undefined ? { open: node.open } : {}),
+        ...(node.children !== undefined ? { children: node.children.map(toOutlineItem) } : {}),
+    };
+}
+
+/** Maps validated outline input to the pdfnative `DocumentParams.outline` value. */
+export function toOutline(value: z.infer<typeof OutlineSchema>): readonly OutlineItem[] | 'auto' {
+    return value === 'auto' ? 'auto' : value.map(toOutlineItem);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Page labels                                                                */
+/* -------------------------------------------------------------------------- */
+
+const PAGE_LABEL_STYLES = ['decimal', 'roman', 'Roman', 'alpha', 'Alpha', 'none'] as const;
+
+export const PAGE_LABELS_INPUT_SCHEMA = {
+    type: 'array',
+    description:
+        'Page-label ranges (the visible page numbers in the viewer, e.g. roman front-matter then decimal body). startPage values must be unique and strictly increasing.',
+    minItems: 1,
+    maxItems: 1000,
+    items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['startPage'],
+        properties: {
+            startPage: { type: 'integer', minimum: 0, description: '0-based index of the first page in this range.' },
+            style: {
+                type: 'string',
+                enum: [...PAGE_LABEL_STYLES],
+                description: "Numbering style. 'none' (or omitted with a prefix) yields prefix-only labels.",
+            },
+            prefix: { type: 'string', maxLength: 64, description: "Optional label prefix (e.g. 'A-')." },
+            start: { type: 'integer', minimum: 1, description: 'First numeric value in the range (default 1).' },
+        },
+    },
+} as const;
+
+export const PageLabelsSchema = z
+    .array(
+        z.object({
+            startPage: z.number().int().min(0),
+            style: z.enum(PAGE_LABEL_STYLES).optional(),
+            prefix: z.string().max(64).optional(),
+            start: z.number().int().min(1).optional(),
+        }),
+    )
+    .min(1)
+    .max(1000);
+
+/** Maps validated page-label input to `DocumentParams.pageLabels`. */
+export function toPageLabels(value: z.infer<typeof PageLabelsSchema>): readonly PageLabelRange[] {
+    return value.map((r) => ({
+        startPage: r.startPage,
+        ...(r.style !== undefined ? { style: r.style } : {}),
+        ...(r.prefix !== undefined ? { prefix: r.prefix } : {}),
+        ...(r.start !== undefined ? { start: r.start } : {}),
+    }));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Viewer preferences                                                         */
+/* -------------------------------------------------------------------------- */
+
+const PAGE_LAYOUTS = ['singlePage', 'oneColumn', 'twoColumnLeft', 'twoColumnRight', 'twoPageLeft', 'twoPageRight'] as const;
+const PAGE_MODES = ['useNone', 'useOutlines', 'useThumbs', 'fullScreen', 'useOC', 'useAttachments'] as const;
+const NON_FULLSCREEN_PAGE_MODES = ['useNone', 'useOutlines', 'useThumbs', 'useOC'] as const;
+
+export const VIEWER_PREFERENCES_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    description: 'Reader presentation hints (catalog /PageLayout, /PageMode, /ViewerPreferences). PDF/A-safe; all optional.',
+    properties: {
+        pageLayout: { type: 'string', enum: [...PAGE_LAYOUTS] },
+        pageMode: { type: 'string', enum: [...PAGE_MODES] },
+        hideToolbar: { type: 'boolean' },
+        hideMenubar: { type: 'boolean' },
+        hideWindowUI: { type: 'boolean' },
+        fitWindow: { type: 'boolean' },
+        centerWindow: { type: 'boolean' },
+        displayDocTitle: { type: 'boolean' },
+        nonFullScreenPageMode: { type: 'string', enum: [...NON_FULLSCREEN_PAGE_MODES] },
+        direction: { type: 'string', enum: ['l2r', 'r2l'] },
+        printScaling: { type: 'string', enum: ['none', 'appDefault'] },
+    },
+} as const;
+
+export const ViewerPreferencesSchema = z.object({
+    pageLayout: z.enum(PAGE_LAYOUTS).optional(),
+    pageMode: z.enum(PAGE_MODES).optional(),
+    hideToolbar: z.boolean().optional(),
+    hideMenubar: z.boolean().optional(),
+    hideWindowUI: z.boolean().optional(),
+    fitWindow: z.boolean().optional(),
+    centerWindow: z.boolean().optional(),
+    displayDocTitle: z.boolean().optional(),
+    nonFullScreenPageMode: z.enum(NON_FULLSCREEN_PAGE_MODES).optional(),
+    direction: z.enum(['l2r', 'r2l']).optional(),
+    printScaling: z.enum(['none', 'appDefault']).optional(),
+});
+
+/** Maps validated viewer-preference input to `PdfLayoutOptions.viewerPreferences`. */
+export function toViewerPreferences(value: z.infer<typeof ViewerPreferencesSchema>): ViewerPreferences {
+    return {
+        ...(value.pageLayout !== undefined ? { pageLayout: value.pageLayout } : {}),
+        ...(value.pageMode !== undefined ? { pageMode: value.pageMode } : {}),
+        ...(value.hideToolbar !== undefined ? { hideToolbar: value.hideToolbar } : {}),
+        ...(value.hideMenubar !== undefined ? { hideMenubar: value.hideMenubar } : {}),
+        ...(value.hideWindowUI !== undefined ? { hideWindowUI: value.hideWindowUI } : {}),
+        ...(value.fitWindow !== undefined ? { fitWindow: value.fitWindow } : {}),
+        ...(value.centerWindow !== undefined ? { centerWindow: value.centerWindow } : {}),
+        ...(value.displayDocTitle !== undefined ? { displayDocTitle: value.displayDocTitle } : {}),
+        ...(value.nonFullScreenPageMode !== undefined ? { nonFullScreenPageMode: value.nonFullScreenPageMode } : {}),
+        ...(value.direction !== undefined ? { direction: value.direction } : {}),
+        ...(value.printScaling !== undefined ? { printScaling: value.printScaling } : {}),
+    };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,5 @@
  * pdfnative-mpc can be embedded in another Node process if desired.
  */
 export { createServer, ensureCompressionReady } from './server.js';
-export type { OutputMode, OutputResult } from './output.js';
+export type { OutputMode, OutputResult, MultiOutputResult, MultiOutputPart } from './output.js';
 export { ToolError, SecurityError } from './errors.js';

--- a/src/output.ts
+++ b/src/output.ts
@@ -114,6 +114,44 @@ export interface OutputResult {
     base64?: string;
 }
 
+/** One PDF part of a {@link MultiOutputResult}. */
+export interface MultiOutputPart {
+    /** 0-based position of this PDF within the produced sequence. */
+    index: number;
+    /** Number of bytes in this PDF. */
+    sizeBytes: number;
+    /** Absolute file path (when `mode === 'file'`). */
+    filePath?: string;
+    /** Base64-encoded PDF (when `mode === 'base64'`). */
+    base64?: string;
+}
+
+/** Result of a tool that produces several PDFs at once (e.g. `split_pdf`). */
+export interface MultiOutputResult {
+    /** The output mode that was used. */
+    mode: OutputMode;
+    /** Number of PDFs produced. */
+    count: number;
+    /** Combined byte size of every produced PDF. */
+    totalBytes: number;
+    /** The individual PDFs, in order. */
+    parts: MultiOutputPart[];
+}
+
+/**
+ * Maximum combined byte size when producing several PDFs at once (200 MiB).
+ * Each individual PDF is additionally capped at {@link MAX_OUTPUT_BYTES}.
+ */
+const MAX_MULTI_OUTPUT_BYTES = 200 * 1024 * 1024;
+
+/**
+ * Derives an indexed sibling path from a base `.pdf` path by inserting a
+ * 1-based suffix before the extension: `report.pdf` → `report-1.pdf`.
+ */
+function indexedOutputPath(basePath: string, oneBasedIndex: number): string {
+    return basePath.replace(/\.pdf$/i, `-${oneBasedIndex}.pdf`);
+}
+
 /**
  * Produces the final tool output: either a base64 string (inline) or writes to a sandboxed file path.
  */
@@ -142,5 +180,64 @@ export async function emitPdf(
         mode: 'base64',
         sizeBytes: bytes.byteLength,
         base64: Buffer.from(bytes).toString('base64'),
+    };
+}
+
+/**
+ * Produces output for a tool that yields several PDFs at once (e.g. `split_pdf`).
+ *
+ * In `base64` mode every PDF is returned inline. In `file` mode each PDF is
+ * written to a 1-based indexed sibling of `outputPath` (`out.pdf` →
+ * `out-1.pdf`, `out-2.pdf`, …); every derived path is independently validated
+ * against the sandbox.
+ *
+ * @throws {ToolError} when any PDF — or the combined output — exceeds the size caps.
+ */
+export async function emitPdfMulti(
+    parts: readonly Uint8Array[],
+    options: { mode: OutputMode; outputPath?: string },
+): Promise<MultiOutputResult> {
+    let totalBytes = 0;
+    for (const bytes of parts) {
+        if (bytes.byteLength > MAX_OUTPUT_BYTES) {
+            throw new ToolError(
+                'OUTPUT_TOO_LARGE',
+                `A produced PDF (${bytes.byteLength} bytes) exceeds the maximum allowed size (${MAX_OUTPUT_BYTES} bytes).`,
+            );
+        }
+        totalBytes += bytes.byteLength;
+    }
+    if (totalBytes > MAX_MULTI_OUTPUT_BYTES) {
+        throw new ToolError(
+            'OUTPUT_TOO_LARGE',
+            `The combined output (${totalBytes} bytes) exceeds the maximum allowed size (${MAX_MULTI_OUTPUT_BYTES} bytes).`,
+        );
+    }
+
+    if (options.mode === 'file') {
+        if (options.outputPath === undefined) {
+            throw new ToolError('MISSING_OUTPUT_PATH', "outputPath is required when outputMode='file'.");
+        }
+        // Validate the base path up-front so a bad path fails before any write.
+        resolveSandboxedPath(options.outputPath);
+        const resultParts: MultiOutputPart[] = [];
+        for (let i = 0; i < parts.length; i++) {
+            const resolved = resolveSandboxedPath(indexedOutputPath(options.outputPath, i + 1));
+            await fs.mkdir(path.dirname(resolved), { recursive: true });
+            await fs.writeFile(resolved, parts[i] as Uint8Array, { flag: 'wx' });
+            resultParts.push({ index: i, sizeBytes: (parts[i] as Uint8Array).byteLength, filePath: resolved });
+        }
+        return { mode: 'file', count: parts.length, totalBytes, parts: resultParts };
+    }
+
+    return {
+        mode: 'base64',
+        count: parts.length,
+        totalBytes,
+        parts: parts.map((bytes, i) => ({
+            index: i,
+            sizeBytes: bytes.byteLength,
+            base64: Buffer.from(bytes).toString('base64'),
+        })),
     };
 }

--- a/src/pagetree.ts
+++ b/src/pagetree.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared error mapping for the pdfnative v1.4.0 page-tree manipulation API
+ * (`mergePdfs` / `splitPdf` / `extractPages`).
+ *
+ * pdfnative throws plain `Error`s for these operations; this helper translates
+ * them into stable {@link ToolError} codes so AI clients get a consistent,
+ * actionable `code` to branch on (see AGENTS.md §6 error reference).
+ */
+import { ToolError } from './errors.js';
+
+/**
+ * Maps a thrown page-tree error to a {@link ToolError} with a stable code.
+ * Always throws — declared `never` so callers can treat the surrounding
+ * `try`/`catch` as exhaustive.
+ *
+ * - Encrypted source           → `ENCRYPTED_SOURCE`
+ * - Output / size-cap exceeded  → `OUTPUT_TOO_LARGE`
+ * - Anything else (malformed)   → `PDF_PARSE_FAILED`
+ */
+export function mapPageTreeError(err: unknown): never {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/encrypt/i.test(message)) {
+        throw new ToolError(
+            'ENCRYPTED_SOURCE',
+            `The page-tree operation does not support encrypted PDFs. Decrypt the source outside the server first. (${message})`,
+        );
+    }
+    if (/\b(exceed|exceeds|too large|maxoutputsize|output size)\b/i.test(message)) {
+        throw new ToolError('OUTPUT_TOO_LARGE', message);
+    }
+    throw new ToolError('PDF_PARSE_FAILED', `Failed to process the source PDF(s): ${message}`);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,7 +14,7 @@ import { initCrypto, initNodeCompression } from 'pdfnative';
 
 import { ToolError } from './errors.js';
 import { getCached, setCached } from './cache.js';
-import { type OutputResult } from './output.js';
+import { type OutputResult, type MultiOutputResult } from './output.js';
 import { readFields, readVerbosity, selectFields } from './projection.js';
 import {
     GENERATE_BASIC_PDF_NAME,
@@ -96,11 +96,37 @@ import {
     extractAttachments,
     type ExtractAttachmentsResult,
 } from './tools/extract-attachments.js';
+import {
+    MERGE_PDFS_NAME,
+    MERGE_PDFS_INPUT_SCHEMA,
+    mergePdfsTool,
+} from './tools/merge-pdfs.js';
+import {
+    SPLIT_PDF_NAME,
+    SPLIT_PDF_INPUT_SCHEMA,
+    splitPdfTool,
+} from './tools/split-pdf.js';
+import {
+    EXTRACT_PAGES_NAME,
+    EXTRACT_PAGES_INPUT_SCHEMA,
+    extractPagesTool,
+} from './tools/extract-pages.js';
 
 // JSON import attribute (Node 22+, TS 5.3+) keeps version in lock-step with package.json.
 // Hardcoded here to keep the build rootDir limited to ./src; tests assert it stays in sync.
-const SERVER_VERSION = '1.2.0';
+const SERVER_VERSION = '1.3.0';
 const SERVER_NAME = 'pdfnative-mcp';
+
+/**
+ * Human-readable server identity surfaced in `serverInfo` (MCP `Implementation`).
+ * `title` is a display name; `description` mirrors `server.json` so hosts and the
+ * MCP registry present consistent metadata during initialization.
+ */
+const SERVER_TITLE = 'pdfnative MCP — PDF generation, signing & introspection';
+const SERVER_DESCRIPTION =
+    'Production-grade MCP server for PDF generation, PDF/A archival, PDF/UA structural validation, ' +
+    'digital signatures (PAdES sign + verify, constant-time node:crypto), page-tree ops (merge / split / extract), ' +
+    'Factur-X invoices, and PDF introspection. 17 tools, 24 scripts, zero runtime dependencies beyond pdfnative and the MCP SDK.';
 
 /**
  * Per-tool API version used by the opt-in cache key and by `_meta.apiVersion`.
@@ -108,7 +134,7 @@ const SERVER_NAME = 'pdfnative-mcp';
  * make a cached response unsafe to serve. Independent from SERVER_VERSION
  * (which tracks the npm package).
  */
-const TOOL_API_VERSION = '1.2.0';
+const TOOL_API_VERSION = '1.3.0';
 
 /** True when the call's input requests a file-mode output (filesystem side-effect). */
 function isFileOutput(input: unknown): boolean {
@@ -119,6 +145,9 @@ function isFileOutput(input: unknown): boolean {
 
 function dispatchOutput(output: unknown, name: string, input: unknown): CallToolResult {
     if (output !== null && typeof output === 'object') {
+        if ('parts' in output && 'count' in output) {
+            return buildMultiSuccessResult(output as MultiOutputResult, name);
+        }
         if ('mode' in output) {
             return buildSuccessResult(output as OutputResult, name);
         }
@@ -171,6 +200,33 @@ const PDF_OUTPUT_SCHEMA = {
     },
 } as const;
 
+/** Output schema for tools that return several PDFs at once (e.g. split_pdf). */
+const MULTI_PDF_OUTPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['mode', 'count', 'totalBytes', 'parts'],
+    description:
+        'Structured result of a tool producing several PDFs. In base64 mode each PDF is delivered out-of-band as its own embedded `resource` content block (data: URI); `parts[]` here carries only the per-PDF size (and `filePath` in file mode) to stay token-frugal.',
+    properties: {
+        mode: { type: 'string', enum: ['base64', 'file'] },
+        count: { type: 'integer', minimum: 0 },
+        totalBytes: { type: 'integer', minimum: 0 },
+        parts: {
+            type: 'array',
+            items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['index', 'sizeBytes'],
+                properties: {
+                    index: { type: 'integer', minimum: 0 },
+                    sizeBytes: { type: 'integer', minimum: 0 },
+                    filePath: { type: 'string', description: "Absolute sandboxed file path (when mode='file')." },
+                },
+            },
+        },
+    },
+} as const;
+
 interface ToolDefinition {
     name: string;
     title: string;
@@ -185,7 +241,7 @@ interface ToolDefinition {
     };
     /** Minimal MCP `_meta.examples` payload — each entry is a self-contained input. */
     examples?: ReadonlyArray<{ readonly title: string; readonly input: Record<string, unknown> }>;
-    handler: (args: unknown) => Promise<OutputResult | InspectPdfResult | VerifyPdfResult | ExtractTextResult | ValidatePdfResult | ExtractAttachmentsResult>;
+    handler: (args: unknown) => Promise<OutputResult | MultiOutputResult | InspectPdfResult | VerifyPdfResult | ExtractTextResult | ValidatePdfResult | ExtractAttachmentsResult>;
 }
 
 const TOOLS: readonly ToolDefinition[] = [
@@ -386,11 +442,50 @@ const TOOLS: readonly ToolDefinition[] = [
         ],
         handler: extractAttachments,
     },
+    {
+        name: MERGE_PDFS_NAME,
+        title: 'Merge PDFs',
+        description:
+            "Concatenate 2–50 source PDFs into a single document (pdfnative v1.4 page-tree API). Each kept page's object graph is deep-copied into a fresh, self-contained PDF. Signatures and AcroForms are dropped (a page-tree edit invalidates /ByteRange); self-contained URI link annotations are preserved unless dropAnnotations=true. Encrypted sources are rejected (ENCRYPTED_SOURCE) — decrypt first. A secure-by-default 256 MiB in-memory assembly guard (maxOutputSizeBytes) guards against memory exhaustion; the emitted PDF is separately capped at 50 MiB (OUTPUT_TOO_LARGE). Returns one PDF (base64 or sandboxed file).",
+        inputSchema: MERGE_PDFS_INPUT_SCHEMA,
+        outputSchema: PDF_OUTPUT_SCHEMA,
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        examples: [
+            { title: 'Merge two PDFs', input: { pdfsBase64: ['<pdf-a-base64>', '<pdf-b-base64>'] } },
+        ],
+        handler: mergePdfsTool,
+    },
+    {
+        name: SPLIT_PDF_NAME,
+        title: 'Split PDF into ranges',
+        description:
+            "Split one PDF into several documents — one per requested page range (pdfnative v1.4 page-tree API). Ranges are 0-based and inclusive; `end` defaults to `start` (a single page). Each output is a fresh, self-contained PDF (signatures/AcroForm dropped; URI links kept unless dropAnnotations=true). Encrypted sources are rejected (ENCRYPTED_SOURCE). In base64 mode every produced PDF is returned as its own embedded resource block; in file mode each is written to a 1-based indexed sibling of outputPath ('out.pdf' → 'out-1.pdf', 'out-2.pdf', …). Use extract_pages instead when you want a single PDF from an arbitrary page subset.",
+        inputSchema: SPLIT_PDF_INPUT_SCHEMA,
+        outputSchema: MULTI_PDF_OUTPUT_SCHEMA,
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        examples: [
+            { title: 'First page and the rest', input: { pdfBase64: '<base64>', ranges: [{ start: 0 }, { start: 1, end: 9 }] } },
+        ],
+        handler: splitPdfTool,
+    },
+    {
+        name: EXTRACT_PAGES_NAME,
+        title: 'Extract pages into one PDF',
+        description:
+            "Extract an arbitrary subset of pages (0-based, in the order given) from a PDF into a SINGLE new document (pdfnative v1.4 page-tree API). The output is a fresh, self-contained PDF (signatures/AcroForm dropped; URI links kept unless dropAnnotations=true). Encrypted sources are rejected (ENCRYPTED_SOURCE). Use split_pdf instead when you need several output PDFs (one per range).",
+        inputSchema: EXTRACT_PAGES_INPUT_SCHEMA,
+        outputSchema: PDF_OUTPUT_SCHEMA,
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        examples: [
+            { title: 'Keep pages 0, 2 and 4', input: { pdfBase64: '<base64>', pages: [0, 2, 4] } },
+        ],
+        handler: extractPagesTool,
+    },
 ];
 
 const TOOL_INDEX: ReadonlyMap<string, ToolDefinition> = new Map(TOOLS.map((t) => [t.name, t]));
 
-const SERVER_INSTRUCTIONS = `pdfnative-mcp bridges the zero-dependency 'pdfnative' v1.3 library to MCP. API version: 1.2.0 (stable).
+const SERVER_INSTRUCTIONS = `pdfnative-mcp bridges the zero-dependency 'pdfnative' v1.4 library to MCP. API version: 1.3.0 (stable).
 
 DECISION TREE — pick the right tool in one step:
   • Plain document (headings, paragraphs, lists)             → ${GENERATE_BASIC_PDF_NAME}
@@ -402,6 +497,9 @@ DECISION TREE — pick the right tool in one step:
   • Sign any PDF (auto-injects placeholder)                  → ${SIGN_PDF_NAME}
   • Customize signature placeholder before signing           → ${PREPARE_SIGNATURE_PLACEHOLDER_NAME} → ${SIGN_PDF_NAME}
   • Factur-X / ZUGFeRD invoice or any PDF with attachments   → ${ADD_ATTACHMENT_NAME}   (NOT generate_basic_pdf)
+  • Concatenate several PDFs into one                        → ${MERGE_PDFS_NAME}
+  • Split a PDF into per-range PDFs                          → ${SPLIT_PDF_NAME}
+  • Pull a subset of pages into one PDF                      → ${EXTRACT_PAGES_NAME}
   • Inspect / assert PDF metadata in CI                      → ${INSPECT_PDF_NAME}
   • Verify all PAdES signatures                              → ${VERIFY_PDF_NAME}
   • Validate PDF/UA accessibility structure                  → ${VALIDATE_PDF_NAME}
@@ -413,18 +511,21 @@ COMMON PITFALLS (read these to avoid retry loops):
   • Barcode 'ecLevel' (L|M|Q|H) applies ONLY to format='qr' and is ignored elsewhere. Use 'H' for printed media.
   • EAN-13 'data' must be exactly 12 or 13 digits (the 13th check digit is auto-computed if you pass 12).
   • sign_pdf accepts ONLY DER-encoded inputs in base64. Convert from PEM with: openssl pkey -in key.pem -outform DER | base64 -w0  (and openssl x509 -in cert.pem -outform DER | base64 -w0 for the cert).
-  • sign_pdf RSA key must be PKCS#1 DER (field 'rsaKeyPkcs1DerBase64'). ECDSA key may be SEC1 or PKCS#8 DER (field 'ecPrivateKeyDerBase64') or the raw 32-byte scalar as 64 hex chars (field 'ecPrivateScalarHex').
+  • sign_pdf RSA key must be PKCS#1 DER (field 'rsaKeyPkcs1DerBase64'). ECDSA key may be SEC1 or PKCS#8 DER (field 'ecPrivateKeyDerBase64') or the raw 32-byte scalar as 64 hex chars (field 'ecPrivateScalarHex'). DER keys are signed with a native constant-time node:crypto provider; the raw scalar uses the pure-JS path.
   • sign_pdf auto-injects a placeholder when missing — call it directly on ANY PDF unless you specifically need to customize the placeholder.
+  • merge_pdfs / split_pdf / extract_pages reject ENCRYPTED PDFs (ENCRYPTED_SOURCE — decrypt first) and ALWAYS drop signatures + AcroForm (a page-tree edit invalidates them). They keep self-contained URI links unless dropAnnotations=true. Page indices/ranges are 0-based. split_pdf returns one PDF per range (file mode writes 'out-1.pdf', 'out-2.pdf', …); extract_pages returns a single PDF.
   • For Factur-X / ZUGFeRD invoices, use add_attachment (PDF/A-3) — generate_basic_pdf cannot embed files.
   • PDF/A: pass pdfA='pdfa2b' for the widest reader compatibility. PDF/A-3 is required when you have attachments.
   • PDF/A text is now robust: embedded newlines ('\\n') in paragraphs are auto-split into separate paragraphs; the Euro sign and other CP-1252 symbols extract correctly (pdfnative 1.3); wrapped table cells get unique per-line MCIDs. Write naturally — no manual workarounds needed.
+  • generate_basic_pdf supports nested lists (a list item may be { text, items: [...] }), a document 'outline' (bookmarks; pass 'auto' to derive from headings) and 'pageLabels' (e.g. roman front-matter then decimal body). All PDF/A-safe.
+  • add_table supports per-cell 'cellBorders' and 'cellVAlign' (top/middle/bottom) — both engage the document backend. generate_basic_pdf, add_table and add_international_text accept 'viewerPreferences' (reader presentation hints, /ViewerPreferences).
   • add_international_text covers 24 scripts and COLRv1 colour emoji; pass 'lang' as a single code or an array (e.g. ["ar","emoji"]) for multi-script runs. Input is NFC-normalised by default; override with normalize ('NFC'|'NFD'|'NFKC'|'NFKD'|false).
   • generate_basic_pdf and add_table accept an optional text 'watermark' (e.g. { text: 'DRAFT' }). Opacity < 1.0 is rejected under pdfA='pdfa1b' (ISO 19005-1 forbids transparency) — use pdfa2b/2u/3b instead.
   • Round-trip: build an invoice with add_attachment, confirm with inspect_pdf (check:['attachments']), then pull the XML back with extract_attachments (filename:'factur-x.xml').
   • outputMode='file' is only available when the host sets PDFNATIVE_MCP_OUTPUT_DIR; otherwise PDFs are returned as base64.
   • TOKEN-FRUGAL READS: the read-only tools (inspect_pdf, verify_pdf, validate_pdf, extract_text, extract_attachments) accept verbosity:'summary' for a compact scalar-only verdict (drops large arrays / full text) and fields:[...] for dot-path projection (e.g. fields:['allValid']). Defaults are unchanged (full output). Generated PDFs are returned as an embedded resource block, not duplicated in structuredContent.
 
-Every tool ships JSON-Schema-typed inputs/outputs, _meta.apiVersion = '1.2.0', and worked-example _meta.examples. See docs/AI_GUIDE.md for a longer walk-through.`;
+Every tool ships JSON-Schema-typed inputs/outputs, _meta.apiVersion = '1.3.0', and worked-example _meta.examples. See docs/AI_GUIDE.md for a longer walk-through.`;
 
 function buildInspectResult(output: InspectPdfResult, toolName: string, input: unknown): CallToolResult {
     const full = output as unknown as Record<string, unknown>;
@@ -556,6 +657,49 @@ function buildSuccessResult(output: OutputResult, toolName: string): CallToolRes
     };
 }
 
+function buildMultiSuccessResult(output: MultiOutputResult, toolName: string): CallToolResult {
+    if (output.mode === 'file') {
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `${toolName}: wrote ${output.count} PDF(s) (${output.totalBytes} bytes total) to ${output.parts
+                        .map((p) => p.filePath)
+                        .join(', ')}`,
+                },
+            ],
+            structuredContent: {
+                mode: output.mode,
+                count: output.count,
+                totalBytes: output.totalBytes,
+                parts: output.parts.map((p) => ({ index: p.index, sizeBytes: p.sizeBytes, filePath: p.filePath })),
+            },
+        };
+    }
+    return {
+        content: [
+            {
+                type: 'text',
+                text: `${toolName}: produced ${output.count} PDF(s) (${output.totalBytes} bytes total), each delivered as an embedded resource below.`,
+            },
+            ...output.parts.map((p) => ({
+                type: 'resource' as const,
+                resource: {
+                    uri: `data:application/pdf;base64,${/* v8 ignore next */ p.base64 ?? ''}`,
+                    mimeType: 'application/pdf',
+                    blob: /* v8 ignore next */ p.base64 ?? '',
+                },
+            })),
+        ],
+        structuredContent: {
+            mode: output.mode,
+            count: output.count,
+            totalBytes: output.totalBytes,
+            parts: output.parts.map((p) => ({ index: p.index, sizeBytes: p.sizeBytes })),
+        },
+    };
+}
+
 function buildErrorResult(err: unknown, toolName: string): CallToolResult {
     if (err instanceof ToolError) {
         return {
@@ -572,7 +716,7 @@ function buildErrorResult(err: unknown, toolName: string): CallToolResult {
 
 export function createServer(): Server {
     const server = new Server(
-        { name: SERVER_NAME, version: SERVER_VERSION },
+        { name: SERVER_NAME, version: SERVER_VERSION, title: SERVER_TITLE, description: SERVER_DESCRIPTION },
         {
             capabilities: { tools: {} },
             instructions: SERVER_INSTRUCTIONS,
@@ -645,5 +789,5 @@ export function ensureCompressionReady(): Promise<void> {
     return _compressionInitPromise;
 }
 
-export const __serverMetadata = { name: SERVER_NAME, version: SERVER_VERSION } as const;
+export const __serverMetadata = { name: SERVER_NAME, version: SERVER_VERSION, title: SERVER_TITLE, description: SERVER_DESCRIPTION } as const;
 export const __serverInstructions = SERVER_INSTRUCTIONS;

--- a/src/tools/add-international-text.ts
+++ b/src/tools/add-international-text.ts
@@ -29,6 +29,11 @@ import { ToolError } from '../errors.js';
 import { splitParagraphSegments } from '../text.js';
 import { PDF_A_ENUM, PdfASchema } from '../pdfa.js';
 import { NORMALIZE_ENUM, NormalizeSchema } from '../normalize.js';
+import {
+    VIEWER_PREFERENCES_INPUT_SCHEMA,
+    ViewerPreferencesSchema,
+    toViewerPreferences,
+} from '../doc-features.js';
 
 export const ADD_INTERNATIONAL_TEXT_NAME = 'add_international_text';
 
@@ -139,6 +144,7 @@ export const ADD_INTERNATIONAL_TEXT_INPUT_SCHEMA = {
             description:
                 "Unicode normalization form applied before shaping. Defaults to 'NFC' (recommended for international scripts: composes decomposed sequences for the widest glyph coverage). Override with 'NFD'/'NFKC'/'NFKD' only for specialised needs.",
         },
+        viewerPreferences: VIEWER_PREFERENCES_INPUT_SCHEMA,
         outputMode: { type: 'string', enum: ['base64', 'file'], default: 'base64' },
         outputPath: { type: 'string' },
     },
@@ -157,6 +163,7 @@ const InputSchema = z.object({
     paragraphs: z.array(z.string().min(1).max(50000)).min(1).max(1000),
     pdfA: PdfASchema.optional(),
     normalize: NormalizeSchema.optional(),
+    viewerPreferences: ViewerPreferencesSchema.optional(),
     outputMode: z.enum(['base64', 'file']).default('base64'),
     outputPath: z.string().optional(),
 });
@@ -189,7 +196,7 @@ export async function addInternationalText(rawInput: unknown): Promise<OutputRes
     if (!parsed.success) {
         throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
     }
-    const { title, lang, paragraphs, pdfA, normalize, outputMode, outputPath } = parsed.data;
+    const { title, lang, paragraphs, pdfA, normalize, viewerPreferences, outputMode, outputPath } = parsed.data;
 
     const langs = normaliseLangs(lang);
     // Auto-register Noto Sans Latin fallback under PDF/A so non-WinAnsi Latin (smart
@@ -218,7 +225,11 @@ export async function addInternationalText(rawInput: unknown): Promise<OutputRes
 
     const bytes = buildDocumentPDFBytes(
         { title, blocks, fontEntries },
-        { normalize: normalize ?? 'NFC', ...(pdfA !== undefined ? { tagged: pdfA } : {}) },
+        {
+            normalize: normalize ?? 'NFC',
+            ...(pdfA !== undefined ? { tagged: pdfA } : {}),
+            ...(viewerPreferences !== undefined ? { viewerPreferences: toViewerPreferences(viewerPreferences) } : {}),
+        },
     );
     return emitPdf(bytes, { mode: outputMode, ...(outputPath !== undefined ? { outputPath } : {}) });
 }

--- a/src/tools/add-table.ts
+++ b/src/tools/add-table.ts
@@ -11,7 +11,7 @@
  *     `buildDocumentPDFBytes` + `TableBlock` since those props live on TableBlock
  *     in pdfnative v1.1.
  */
-import { buildDocumentPDFBytes, buildPDFBytes, type DocumentBlock, type TableBlock } from 'pdfnative';
+import { buildDocumentPDFBytes, buildPDFBytes, type CellBorders, type DocumentBlock, type TableBlock } from 'pdfnative';
 import { z } from 'zod';
 import { emitPdf, type OutputResult } from '../output.js';
 import { ToolError } from '../errors.js';
@@ -22,6 +22,55 @@ import {
     toWatermarkOptions,
     assertWatermarkPdfACompatible,
 } from '../watermark.js';
+import {
+    VIEWER_PREFERENCES_INPUT_SCHEMA,
+    ViewerPreferencesSchema,
+    toViewerPreferences,
+} from '../doc-features.js';
+
+const CELL_BORDER_STYLES = ['solid', 'dashed', 'dotted'] as const;
+const CELL_VALIGNS = ['top', 'middle', 'bottom'] as const;
+
+const CELL_BORDERS_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    description:
+        'Per-cell vector borders (pdfnative v1.4). Switches the backend to buildDocumentPDFBytes. Choose individual sides or `all`.',
+    properties: {
+        top: { type: 'boolean' },
+        right: { type: 'boolean' },
+        bottom: { type: 'boolean' },
+        left: { type: 'boolean' },
+        all: { type: 'boolean', description: 'Draw all four edges (overrides the individual side flags).' },
+        color: { type: 'string', description: "Stroke colour as a PDF operator string ('0.8 0.8 0.8') or hex. Default light grey." },
+        width: { type: 'number', minimum: 0, maximum: 10, description: 'Stroke width in points (default 0.5).' },
+        style: { type: 'string', enum: [...CELL_BORDER_STYLES], description: "Stroke style (default 'solid')." },
+    },
+} as const;
+
+const CellBordersSchema = z.object({
+    top: z.boolean().optional(),
+    right: z.boolean().optional(),
+    bottom: z.boolean().optional(),
+    left: z.boolean().optional(),
+    all: z.boolean().optional(),
+    color: z.string().min(1).max(64).optional(),
+    width: z.number().min(0).max(10).optional(),
+    style: z.enum(CELL_BORDER_STYLES).optional(),
+});
+
+function toCellBorders(value: z.infer<typeof CellBordersSchema>): CellBorders {
+    return {
+        ...(value.top !== undefined ? { top: value.top } : {}),
+        ...(value.right !== undefined ? { right: value.right } : {}),
+        ...(value.bottom !== undefined ? { bottom: value.bottom } : {}),
+        ...(value.left !== undefined ? { left: value.left } : {}),
+        ...(value.all !== undefined ? { all: value.all } : {}),
+        ...(value.color !== undefined ? { color: value.color } : {}),
+        ...(value.width !== undefined ? { width: value.width } : {}),
+        ...(value.style !== undefined ? { style: value.style } : {}),
+    };
+}
 
 export const ADD_TABLE_NAME = 'add_table';
 
@@ -113,12 +162,19 @@ export const ADD_TABLE_INPUT_SCHEMA = {
             maximum: 50,
             description: 'Horizontal cell padding in points applied to both insets (default 3). pdfnative v1.2.',
         },
+        cellBorders: CELL_BORDERS_INPUT_SCHEMA,
+        cellVAlign: {
+            type: 'string',
+            enum: [...CELL_VALIGNS],
+            description: 'Vertical alignment of cell content (pdfnative v1.4). Switches the backend to buildDocumentPDFBytes.',
+        },
         pdfA: {
             type: 'string',
             enum: [...PDF_A_ENUM],
             description: PDF_A_FIELD_DESCRIPTION,
         },
         watermark: WATERMARK_INPUT_SCHEMA,
+        viewerPreferences: VIEWER_PREFERENCES_INPUT_SCHEMA,
         outputMode: {
             type: 'string',
             enum: ['base64', 'file'],
@@ -156,8 +212,11 @@ const InputSchema = z.object({
     caption: z.string().max(200).optional(),
     minRowHeight: z.number().min(1).max(200).optional(),
     cellPadding: z.number().min(0).max(50).optional(),
+    cellBorders: CellBordersSchema.optional(),
+    cellVAlign: z.enum(CELL_VALIGNS).optional(),
     pdfA: PdfASchema.optional(),
     watermark: WatermarkSchema.optional(),
+    viewerPreferences: ViewerPreferencesSchema.optional(),
     outputMode: z.enum(['base64', 'file']).default('base64'),
     outputPath: z.string().optional(),
 });
@@ -167,7 +226,7 @@ export async function addTable(rawInput: unknown): Promise<OutputResult> {
     if (!parsed.success) {
         throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
     }
-    const { title, headers, rows, infoItems, footerText, autoFitColumns, clipCells, wrap, repeatHeader, zebra, caption, minRowHeight, cellPadding, pdfA, watermark, outputMode, outputPath } = parsed.data;
+    const { title, headers, rows, infoItems, footerText, autoFitColumns, clipCells, wrap, repeatHeader, zebra, caption, minRowHeight, cellPadding, cellBorders, cellVAlign, pdfA, watermark, viewerPreferences, outputMode, outputPath } = parsed.data;
     assertWatermarkPdfACompatible(watermark, pdfA);
 
     // Validate column count consistency: every row must have the same length as headers
@@ -180,8 +239,12 @@ export async function addTable(rawInput: unknown): Promise<OutputResult> {
         }
     }
 
-    const smartTableField = wrap !== undefined || repeatHeader !== undefined || zebra !== undefined || caption !== undefined || minRowHeight !== undefined || cellPadding !== undefined;
+    const smartTableField = wrap !== undefined || repeatHeader !== undefined || zebra !== undefined || caption !== undefined || minRowHeight !== undefined || cellPadding !== undefined || cellBorders !== undefined || cellVAlign !== undefined;
     const useDocumentBackend = autoFitColumns !== undefined || clipCells !== undefined || pdfA !== undefined || watermark !== undefined || smartTableField;
+
+    const layout = {
+        ...(viewerPreferences !== undefined ? { viewerPreferences: toViewerPreferences(viewerPreferences) } : {}),
+    };
 
     let bytes: Uint8Array;
     if (useDocumentBackend) {
@@ -197,6 +260,8 @@ export async function addTable(rawInput: unknown): Promise<OutputResult> {
             ...(caption !== undefined ? { caption } : {}),
             ...(minRowHeight !== undefined ? { minRowHeight } : {}),
             ...(cellPadding !== undefined ? { cellPadding } : {}),
+            ...(cellBorders !== undefined ? { cellBorders: toCellBorders(cellBorders) } : {}),
+            ...(cellVAlign !== undefined ? { cellVAlign } : {}),
         };
         const blocks: DocumentBlock[] = [];
         if (infoItems !== undefined && infoItems.length > 0) {
@@ -210,18 +275,22 @@ export async function addTable(rawInput: unknown): Promise<OutputResult> {
             {
                 ...(pdfA !== undefined ? { tagged: pdfA } : {}),
                 ...(watermark !== undefined ? { watermark: toWatermarkOptions(watermark) } : {}),
+                ...layout,
             },
         );
     } else {
-        bytes = buildPDFBytes({
-            title,
-            infoItems: (infoItems ?? []).map((item) => ({ label: item.label, value: item.value })),
-            balanceText: '',
-            countText: '',
-            headers,
-            rows: rows.map((cells) => ({ cells, type: '', pointed: false })),
-            footerText: footerText ?? '',
-        });
+        bytes = buildPDFBytes(
+            {
+                title,
+                infoItems: (infoItems ?? []).map((item) => ({ label: item.label, value: item.value })),
+                balanceText: '',
+                countText: '',
+                headers,
+                rows: rows.map((cells) => ({ cells, type: '', pointed: false })),
+                footerText: footerText ?? '',
+            },
+            layout,
+        );
     }
 
     return emitPdf(bytes, { mode: outputMode, ...(outputPath !== undefined ? { outputPath } : {}) });

--- a/src/tools/extract-pages.ts
+++ b/src/tools/extract-pages.ts
@@ -1,0 +1,101 @@
+/**
+ * Tool: extract_pages
+ *
+ * Extracts an arbitrary subset of pages from a PDF into a single new document,
+ * in the order given, using pdfnative's page-tree manipulation API
+ * (`extractPages`, new in pdfnative v1.4.0). The output is a fresh,
+ * self-contained PDF.
+ *
+ * Use `split_pdf` instead when you need several output PDFs (one per range);
+ * `extract_pages` always produces exactly one PDF.
+ *
+ * Faithful-wrapper notes (pdfnative semantics):
+ *   - Encrypted sources are rejected → `ENCRYPTED_SOURCE`.
+ *   - Signatures and the `/AcroForm` are dropped; self-contained URI links are
+ *     kept unless `dropAnnotations` is set.
+ *   - Page indices are 0-based; order is preserved.
+ */
+import { extractPages, type MergeOptions } from 'pdfnative';
+import { z } from 'zod';
+
+import { emitPdf, type OutputResult } from '../output.js';
+import { ToolError } from '../errors.js';
+import { mapPageTreeError } from '../pagetree.js';
+
+export const EXTRACT_PAGES_NAME = 'extract_pages';
+
+export const EXTRACT_PAGES_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['pdfBase64', 'pages'],
+    properties: {
+        pdfBase64: {
+            type: 'string',
+            minLength: 4,
+            description: 'Base64-encoded source PDF. Must not be encrypted.',
+        },
+        pages: {
+            type: 'array',
+            description: '0-based page indices to keep, in output order. Duplicates and out-of-range indices are rejected.',
+            minItems: 1,
+            maxItems: 5000,
+            items: { type: 'integer', minimum: 0 },
+        },
+        dropAnnotations: {
+            type: 'boolean',
+            default: false,
+            description: 'When true, drop ALL annotations. Default keeps self-contained URI link annotations.',
+        },
+        maxOutputSizeBytes: {
+            type: 'integer',
+            minimum: 1,
+            description: 'Maximum size, in bytes, of the produced PDF. Defaults to 268435456 (256 MiB).',
+        },
+        outputMode: { type: 'string', enum: ['base64', 'file'], default: 'base64' },
+        outputPath: { type: 'string' },
+    },
+} as const;
+
+const InputSchema = z.object({
+    pdfBase64: z.string().min(4),
+    pages: z.array(z.number().int().min(0)).min(1).max(5000),
+    dropAnnotations: z.boolean().default(false),
+    maxOutputSizeBytes: z.number().int().positive().optional(),
+    outputMode: z.enum(['base64', 'file']).default('base64'),
+    outputPath: z.string().optional(),
+});
+
+function decodeBase64(value: string, field: string): Uint8Array {
+    try {
+        return new Uint8Array(Buffer.from(value, 'base64'));
+    } catch {
+        throw new ToolError('VALIDATION_ERROR', `${field} is not valid base64.`);
+    }
+}
+
+export async function extractPagesTool(rawInput: unknown): Promise<OutputResult> {
+    const parsed = InputSchema.safeParse(rawInput);
+    if (!parsed.success) {
+        throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
+    }
+    const input = parsed.data;
+
+    const source = decodeBase64(input.pdfBase64, 'pdfBase64');
+
+    const opts: MergeOptions = {
+        dropAnnotations: input.dropAnnotations,
+        ...(input.maxOutputSizeBytes !== undefined ? { maxOutputSize: input.maxOutputSizeBytes } : {}),
+    };
+
+    let extracted: Uint8Array;
+    try {
+        extracted = extractPages(source, input.pages, opts);
+    } catch (err) {
+        mapPageTreeError(err);
+    }
+
+    return emitPdf(extracted, {
+        mode: input.outputMode,
+        ...(input.outputPath !== undefined ? { outputPath: input.outputPath } : {}),
+    });
+}

--- a/src/tools/generate-basic-pdf.ts
+++ b/src/tools/generate-basic-pdf.ts
@@ -18,6 +18,20 @@ import {
     toWatermarkOptions,
     assertWatermarkPdfACompatible,
 } from '../watermark.js';
+import {
+    LIST_ITEMS_INPUT_SCHEMA,
+    ListItemsSchema,
+    toListItems,
+    OUTLINE_INPUT_SCHEMA,
+    OutlineSchema,
+    toOutline,
+    PAGE_LABELS_INPUT_SCHEMA,
+    PageLabelsSchema,
+    toPageLabels,
+    VIEWER_PREFERENCES_INPUT_SCHEMA,
+    ViewerPreferencesSchema,
+    toViewerPreferences,
+} from '../doc-features.js';
 
 export const GENERATE_BASIC_PDF_NAME = 'generate_basic_pdf';
 
@@ -69,12 +83,7 @@ export const GENERATE_BASIC_PDF_INPUT_SCHEMA = {
                         properties: {
                             type: { const: 'list' },
                             style: { type: 'string', enum: ['bullet', 'numbered'], default: 'bullet' },
-                            items: {
-                                type: 'array',
-                                minItems: 1,
-                                maxItems: 1000,
-                                items: { type: 'string', minLength: 1, maxLength: 1000 },
-                            },
+                            items: LIST_ITEMS_INPUT_SCHEMA,
                         },
                     },
                     {
@@ -113,6 +122,9 @@ export const GENERATE_BASIC_PDF_INPUT_SCHEMA = {
             enum: [...NORMALIZE_ENUM],
             description: NORMALIZE_FIELD_DESCRIPTION,
         },
+        outline: OUTLINE_INPUT_SCHEMA,
+        pageLabels: PAGE_LABELS_INPUT_SCHEMA,
+        viewerPreferences: VIEWER_PREFERENCES_INPUT_SCHEMA,
         outputMode: {
             type: 'string',
             enum: ['base64', 'file'],
@@ -144,7 +156,7 @@ const InputSchema = z.object({
                 z.object({
                     type: z.literal('list'),
                     style: z.enum(['bullet', 'numbered']).default('bullet'),
-                    items: z.array(z.string().min(1).max(1000)).min(1).max(1000),
+                    items: ListItemsSchema,
                 }),
                 z.object({ type: z.literal('pageBreak') }),
                 z.object({
@@ -159,6 +171,9 @@ const InputSchema = z.object({
     pdfA: PdfASchema.optional(),
     watermark: WatermarkSchema.optional(),
     normalize: NormalizeSchema.optional(),
+    outline: OutlineSchema.optional(),
+    pageLabels: PageLabelsSchema.optional(),
+    viewerPreferences: ViewerPreferencesSchema.optional(),
     outputMode: z.enum(['base64', 'file']).default('base64'),
     outputPath: z.string().optional(),
 });
@@ -168,7 +183,8 @@ export async function generateBasicPdf(rawInput: unknown): Promise<OutputResult>
     if (!parsed.success) {
         throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
     }
-    const { title, blocks, footerText, pdfA, watermark, normalize, outputMode, outputPath } = parsed.data;
+    const { title, blocks, footerText, pdfA, watermark, normalize, outline, pageLabels, viewerPreferences, outputMode, outputPath } =
+        parsed.data;
     assertWatermarkPdfACompatible(watermark, pdfA);
 
     const docBlocks: DocumentBlock[] = blocks.flatMap((block): DocumentBlock[] => {
@@ -178,7 +194,7 @@ export async function generateBasicPdf(rawInput: unknown): Promise<OutputResult>
             case 'paragraph':
                 return splitParagraphSegments(block.text).map((text) => ({ type: 'paragraph', text }));
             case 'list':
-                return [{ type: 'list', items: block.items, style: block.style }];
+                return [{ type: 'list', items: toListItems(block.items), style: block.style }];
             case 'pageBreak':
                 return [{ type: 'pageBreak' }];
             case 'spacer':
@@ -194,11 +210,14 @@ export async function generateBasicPdf(rawInput: unknown): Promise<OutputResult>
             title,
             blocks: docBlocks,
             ...(footerText !== undefined ? { footerText } : {}),
+            ...(outline !== undefined ? { outline: toOutline(outline) } : {}),
+            ...(pageLabels !== undefined ? { pageLabels: toPageLabels(pageLabels) } : {}),
         },
         {
             ...(pdfA !== undefined ? { tagged: pdfA } : {}),
             ...(watermark !== undefined ? { watermark: toWatermarkOptions(watermark) } : {}),
             ...(normalize !== undefined ? { normalize } : {}),
+            ...(viewerPreferences !== undefined ? { viewerPreferences: toViewerPreferences(viewerPreferences) } : {}),
         },
     );
 

--- a/src/tools/merge-pdfs.ts
+++ b/src/tools/merge-pdfs.ts
@@ -1,0 +1,100 @@
+/**
+ * Tool: merge_pdfs
+ *
+ * Concatenates 2–50 source PDFs into a single document using pdfnative's
+ * page-tree manipulation API (`mergePdfs`, new in pdfnative v1.4.0). Each
+ * kept page's transitive object graph is deep-copied into a fresh object-number
+ * space, so the output is fully self-contained.
+ *
+ * Faithful-wrapper notes (pdfnative semantics, surfaced verbatim):
+ *   - Encrypted sources are rejected (decrypt outside the server first) →
+ *     `ENCRYPTED_SOURCE`.
+ *   - Any existing signatures and the `/AcroForm` are dropped — a page-tree
+ *     edit necessarily invalidates `/ByteRange`. Self-contained URI `/Link`
+ *     annotations are preserved unless `dropAnnotations` is set.
+ *   - A secure-by-default 256 MiB *assembly* guard (`maxOutputSizeBytes`, the
+ *     pdfnative `maxOutputSize`) rejects oversized object graphs before they are
+ *     materialised. The emitted PDF is additionally capped at 50 MiB by the
+ *     output layer (the effective per-PDF ceiling) → `OUTPUT_TOO_LARGE`.
+ */
+import { mergePdfs, type MergeOptions } from 'pdfnative';
+import { z } from 'zod';
+
+import { emitPdf, type OutputResult } from '../output.js';
+import { ToolError } from '../errors.js';
+import { mapPageTreeError } from '../pagetree.js';
+
+export const MERGE_PDFS_NAME = 'merge_pdfs';
+
+export const MERGE_PDFS_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['pdfsBase64'],
+    properties: {
+        pdfsBase64: {
+            type: 'array',
+            description:
+                'Base64-encoded source PDFs to concatenate, in order. 2–50 documents. Signatures and AcroForms are dropped (a page-tree edit invalidates them); encrypted PDFs are rejected.',
+            minItems: 2,
+            maxItems: 50,
+            items: { type: 'string', minLength: 4 },
+        },
+        dropAnnotations: {
+            type: 'boolean',
+            default: false,
+            description:
+                'When true, drop ALL annotations. Default (false) keeps self-contained URI link annotations and drops cross-document/widget annotations.',
+        },
+        maxOutputSizeBytes: {
+            type: 'integer',
+            minimum: 1,
+            description:
+                'In-memory assembly guard (pdfnative maxOutputSize): the merge throws before materialising an object graph larger than this. Defaults to 268435456 (256 MiB). Note the emitted PDF is separately capped at 50 MiB by the output layer.',
+        },
+        outputMode: { type: 'string', enum: ['base64', 'file'], default: 'base64' },
+        outputPath: { type: 'string' },
+    },
+} as const;
+
+const InputSchema = z.object({
+    pdfsBase64: z.array(z.string().min(4)).min(2).max(50),
+    dropAnnotations: z.boolean().default(false),
+    maxOutputSizeBytes: z.number().int().positive().optional(),
+    outputMode: z.enum(['base64', 'file']).default('base64'),
+    outputPath: z.string().optional(),
+});
+
+function decodeBase64(value: string, field: string): Uint8Array {
+    try {
+        return new Uint8Array(Buffer.from(value, 'base64'));
+    } catch {
+        throw new ToolError('VALIDATION_ERROR', `${field} is not valid base64.`);
+    }
+}
+
+export async function mergePdfsTool(rawInput: unknown): Promise<OutputResult> {
+    const parsed = InputSchema.safeParse(rawInput);
+    if (!parsed.success) {
+        throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
+    }
+    const input = parsed.data;
+
+    const sources = input.pdfsBase64.map((b64, i) => decodeBase64(b64, `pdfsBase64[${i}]`));
+
+    const opts: MergeOptions = {
+        dropAnnotations: input.dropAnnotations,
+        ...(input.maxOutputSizeBytes !== undefined ? { maxOutputSize: input.maxOutputSizeBytes } : {}),
+    };
+
+    let merged: Uint8Array;
+    try {
+        merged = mergePdfs(sources, opts);
+    } catch (err) {
+        mapPageTreeError(err);
+    }
+
+    return emitPdf(merged, {
+        mode: input.outputMode,
+        ...(input.outputPath !== undefined ? { outputPath: input.outputPath } : {}),
+    });
+}

--- a/src/tools/sign-pdf.ts
+++ b/src/tools/sign-pdf.ts
@@ -15,6 +15,12 @@
  *   - Signer metadata (`signerName`, `reason`, `location`, `contactInfo`,
  *     `signingTime`) is written into the `/Sig` dictionary at signing time
  *     (this matches PAdES Baseline behaviour and pdfnative v1.2 semantics).
+ *
+ * v1.3.0 security:
+ *   - Constant-time signing via `node:crypto`. RSA (PKCS#1) and ECDSA P-256
+ *     (SEC1 / PKCS#8) keys are routed through a native, constant-time
+ *     {@link buildNodeCryptoProvider}; the pure-JS RSA/ECDSA math is used only
+ *     as a fallback (e.g. a bare P-256 scalar without its public point).
  */
 import {
     addSignaturePlaceholder,
@@ -29,6 +35,7 @@ import { emitPdf, type OutputResult } from '../output.js';
 import { ToolError } from '../errors.js';
 import { parseEcPrivateKeyDer } from '../ec-key.js';
 import { hasSignaturePlaceholder } from '../pdf-introspection.js';
+import { buildNodeCryptoProvider } from '../crypto-provider.js';
 
 export const SIGN_PDF_NAME = 'sign_pdf';
 
@@ -190,16 +197,27 @@ export async function signPdf(rawInput: unknown): Promise<OutputResult> {
     let options: PdfSignOptions;
     if (input.algorithm === 'rsa-sha256') {
         const rsaDer = decodeBase64(input.rsaKeyPkcs1DerBase64 as string, 'rsaKeyPkcs1DerBase64');
-        const rsaKey = parseRsaPrivateKey(rsaDer);
-        options = { ...baseOptions, rsaKey };
-    } else {
-        let d: bigint;
-        if (input.ecPrivateScalarHex !== undefined) {
-            d = hexToBigInt(input.ecPrivateScalarHex);
+        // Prefer the native constant-time signer; fall back to pdfnative's pure-JS path.
+        const provider = buildNodeCryptoProvider({ algorithm: 'rsa-sha256', der: rsaDer, keyType: 'pkcs1' });
+        if (provider !== null) {
+            options = { ...baseOptions, provider };
         } else {
-            const ecDer = decodeBase64(input.ecPrivateKeyDerBase64 as string, 'ecPrivateKeyDerBase64');
-            d = parseEcPrivateKeyDer(ecDer);
+            const rsaKey = parseRsaPrivateKey(rsaDer);
+            options = { ...baseOptions, rsaKey };
         }
+    } else if (input.ecPrivateKeyDerBase64 !== undefined) {
+        const ecDer = decodeBase64(input.ecPrivateKeyDerBase64, 'ecPrivateKeyDerBase64');
+        const provider = buildNodeCryptoProvider({ algorithm: 'ecdsa-sha256', der: ecDer, keyType: 'sec1' });
+        if (provider !== null) {
+            options = { ...baseOptions, provider };
+        } else {
+            const d = parseEcPrivateKeyDer(ecDer);
+            options = { ...baseOptions, ecKey: { d } };
+        }
+    } else {
+        // Raw P-256 scalar: node:crypto cannot import it without the public point,
+        // so use pdfnative's pure-JS ECDSA path.
+        const d = hexToBigInt(input.ecPrivateScalarHex as string);
         options = { ...baseOptions, ecKey: { d } };
     }
 

--- a/src/tools/split-pdf.ts
+++ b/src/tools/split-pdf.ts
@@ -1,0 +1,128 @@
+/**
+ * Tool: split_pdf
+ *
+ * Splits a single PDF into several documents — one per requested page range —
+ * using pdfnative's page-tree manipulation API (`splitPdf`, new in pdfnative
+ * v1.4.0). Each output is a fresh, self-contained PDF.
+ *
+ * Multi-output: in base64 mode every produced PDF is returned inline (one
+ * `resource` block each); in file mode each PDF is written to a 1-based indexed
+ * sibling of `outputPath` (`out.pdf` → `out-1.pdf`, `out-2.pdf`, …).
+ *
+ * Faithful-wrapper notes (pdfnative semantics):
+ *   - Encrypted sources are rejected → `ENCRYPTED_SOURCE`.
+ *   - Signatures and the `/AcroForm` are dropped; self-contained URI links are
+ *     kept unless `dropAnnotations` is set.
+ *   - Ranges are 0-based and inclusive; `end` defaults to `start`.
+ */
+import { splitPdf, type MergeOptions, type PageRange } from 'pdfnative';
+import { z } from 'zod';
+
+import { emitPdfMulti, type MultiOutputResult } from '../output.js';
+import { ToolError } from '../errors.js';
+import { mapPageTreeError } from '../pagetree.js';
+
+export const SPLIT_PDF_NAME = 'split_pdf';
+
+export const SPLIT_PDF_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['pdfBase64', 'ranges'],
+    properties: {
+        pdfBase64: {
+            type: 'string',
+            minLength: 4,
+            description: 'Base64-encoded source PDF. Must not be encrypted.',
+        },
+        ranges: {
+            type: 'array',
+            description:
+                'Page ranges to extract, one output PDF per range. 0-based, inclusive; `end` defaults to `start` (a single page).',
+            minItems: 1,
+            maxItems: 1000,
+            items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['start'],
+                properties: {
+                    start: { type: 'integer', minimum: 0, description: 'First page index (0-based, inclusive).' },
+                    end: { type: 'integer', minimum: 0, description: 'Last page index (0-based, inclusive). Defaults to start.' },
+                },
+            },
+        },
+        dropAnnotations: {
+            type: 'boolean',
+            default: false,
+            description: 'When true, drop ALL annotations. Default keeps self-contained URI link annotations.',
+        },
+        maxOutputSizeBytes: {
+            type: 'integer',
+            minimum: 1,
+            description: 'Maximum size, in bytes, of each produced PDF. Defaults to 268435456 (256 MiB).',
+        },
+        outputMode: { type: 'string', enum: ['base64', 'file'], default: 'base64' },
+        outputPath: {
+            type: 'string',
+            description: "Base output path (file mode). Each PDF is written to an indexed sibling: 'out.pdf' → 'out-1.pdf', 'out-2.pdf', …",
+        },
+    },
+} as const;
+
+const InputSchema = z.object({
+    pdfBase64: z.string().min(4),
+    ranges: z
+        .array(
+            z
+                .object({
+                    start: z.number().int().min(0),
+                    end: z.number().int().min(0).optional(),
+                })
+                .superRefine((r, ctx) => {
+                    if (r.end !== undefined && r.end < r.start) {
+                        ctx.addIssue({ code: 'custom', message: `range end (${r.end}) must be >= start (${r.start}).` });
+                    }
+                }),
+        )
+        .min(1)
+        .max(1000),
+    dropAnnotations: z.boolean().default(false),
+    maxOutputSizeBytes: z.number().int().positive().optional(),
+    outputMode: z.enum(['base64', 'file']).default('base64'),
+    outputPath: z.string().optional(),
+});
+
+function decodeBase64(value: string, field: string): Uint8Array {
+    try {
+        return new Uint8Array(Buffer.from(value, 'base64'));
+    } catch {
+        throw new ToolError('VALIDATION_ERROR', `${field} is not valid base64.`);
+    }
+}
+
+export async function splitPdfTool(rawInput: unknown): Promise<MultiOutputResult> {
+    const parsed = InputSchema.safeParse(rawInput);
+    if (!parsed.success) {
+        throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
+    }
+    const input = parsed.data;
+
+    const source = decodeBase64(input.pdfBase64, 'pdfBase64');
+    const ranges: PageRange[] = input.ranges.map((r) => (r.end !== undefined ? { start: r.start, end: r.end } : { start: r.start }));
+
+    const opts: MergeOptions = {
+        dropAnnotations: input.dropAnnotations,
+        ...(input.maxOutputSizeBytes !== undefined ? { maxOutputSize: input.maxOutputSizeBytes } : {}),
+    };
+
+    let parts: Uint8Array[];
+    try {
+        parts = splitPdf(source, ranges, opts);
+    } catch (err) {
+        mapPageTreeError(err);
+    }
+
+    return emitPdfMulti(parts, {
+        mode: input.outputMode,
+        ...(input.outputPath !== undefined ? { outputPath: input.outputPath } : {}),
+    });
+}

--- a/tests/_pagetree-fixtures.ts
+++ b/tests/_pagetree-fixtures.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared fixtures for the page-tree tool tests (merge / split / extract).
+ * Builds real multi-page PDFs (and an encrypted one) entirely in-process.
+ */
+import { buildDocumentPDFBytes, type DocumentBlock } from 'pdfnative';
+import { generateBasicPdf } from '../src/tools/generate-basic-pdf.js';
+
+/** Build an N-page PDF (one heading per page) and return it as base64. */
+export async function makePdfBase64(pages: number, label = 'Doc'): Promise<string> {
+    const blocks: Array<{ type: string; text?: string; level?: number }> = [];
+    for (let i = 0; i < pages; i++) {
+        if (i > 0) blocks.push({ type: 'pageBreak' });
+        blocks.push({ type: 'heading', text: `${label} — page ${i + 1}`, level: 1 });
+    }
+    const result = await generateBasicPdf({ title: label, blocks });
+    return result.base64 as string;
+}
+
+/** Build an encrypted (owner-password) PDF and return it as base64. */
+export function makeEncryptedPdfBase64(): string {
+    const blocks: DocumentBlock[] = [{ type: 'paragraph', text: 'secret' }];
+    const bytes = buildDocumentPDFBytes(
+        { title: 'Secret', blocks },
+        { encryption: { ownerPassword: 'owner-secret' } },
+    );
+    return Buffer.from(bytes).toString('base64');
+}

--- a/tests/crypto-provider.test.ts
+++ b/tests/crypto-provider.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for the node:crypto signature provider (v1.3.0).
+ */
+import { describe, it, expect } from 'vitest';
+import { generateKeyPairSync } from 'node:crypto';
+
+import { buildNodeCryptoProvider } from '../src/crypto-provider.js';
+
+describe('buildNodeCryptoProvider', () => {
+    it('returns null when the RSA key bytes cannot be imported', () => {
+        const provider = buildNodeCryptoProvider({
+            algorithm: 'rsa-sha256',
+            der: new Uint8Array([1, 2, 3, 4]),
+            keyType: 'pkcs1',
+        });
+        expect(provider).toBeNull();
+    });
+
+    it('returns null when the EC key bytes cannot be imported', () => {
+        const provider = buildNodeCryptoProvider({
+            algorithm: 'ecdsa-sha256',
+            der: new Uint8Array([9, 9, 9, 9]),
+            keyType: 'sec1',
+        });
+        expect(provider).toBeNull();
+    });
+
+    it('signs with a real RSA PKCS#1 key and returns a non-empty signature', () => {
+        const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+        const der = new Uint8Array(privateKey.export({ format: 'der', type: 'pkcs1' }));
+        const provider = buildNodeCryptoProvider({ algorithm: 'rsa-sha256', der, keyType: 'pkcs1' });
+        expect(provider).not.toBeNull();
+        const sig = provider!.sign(new Uint8Array([1, 2, 3, 4, 5]), 'rsa-sha256');
+        // RSA-2048 signature is 256 bytes.
+        expect(sig.byteLength).toBe(256);
+    });
+
+    it('signs with a real EC P-256 PKCS#8 key (DER-encoded ECDSA)', () => {
+        const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+        const der = new Uint8Array(privateKey.export({ format: 'der', type: 'pkcs8' }));
+        const provider = buildNodeCryptoProvider({ algorithm: 'ecdsa-sha256', der, keyType: 'pkcs8' });
+        expect(provider).not.toBeNull();
+        const sig = provider!.sign(new Uint8Array([1, 2, 3, 4, 5]), 'ecdsa-sha256');
+        // DER-encoded ECDSA signature begins with a SEQUENCE tag (0x30).
+        expect(sig[0]).toBe(0x30);
+        expect(sig.byteLength).toBeGreaterThan(8);
+    });
+});

--- a/tests/doc-features.test.ts
+++ b/tests/doc-features.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the pdfnative v1.4 document features threaded into the generation
+ * tools in v1.3.0: nested lists, document outline / bookmarks, page labels,
+ * viewer preferences (generate_basic_pdf) and cell borders + vertical
+ * alignment (add_table).
+ *
+ * These options are additive: when omitted, output is unchanged. The assertions
+ * confirm valid PDFs and, where cheaply observable, the presence of the
+ * corresponding catalog structures (/Outlines, /PageLabels, /ViewerPreferences).
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { generateBasicPdf } from '../src/tools/generate-basic-pdf.js';
+import { addTable } from '../src/tools/add-table.js';
+import { ensureCompressionReady } from '../src/server.js';
+import { ToolError } from '../src/errors.js';
+import { assertValidPdf } from './_pdf-assert.js';
+
+const ENV_KEY = 'PDFNATIVE_MCP_OUTPUT_DIR';
+
+function decodedText(base64: string): string {
+    return Buffer.from(base64, 'base64').toString('latin1');
+}
+
+describe('v1.4 document features', () => {
+    beforeAll(async () => {
+        delete process.env[ENV_KEY];
+        await ensureCompressionReady();
+    });
+
+    describe('generate_basic_pdf — nested lists', () => {
+        it('renders a nested list (object items with sub-lists)', async () => {
+            const result = await generateBasicPdf({
+                title: 'Nested',
+                blocks: [
+                    {
+                        type: 'list',
+                        style: 'bullet',
+                        items: [
+                            'Top-level item',
+                            { text: 'Parent', items: ['Child A', { text: 'Child B', items: ['Grandchild'] }] },
+                        ],
+                    },
+                ],
+            });
+            assertValidPdf(result.base64 as string);
+        });
+
+        it('is unchanged for string-only lists (still valid)', async () => {
+            const result = await generateBasicPdf({
+                title: 'Flat',
+                blocks: [{ type: 'list', style: 'numbered', items: ['One', 'Two', 'Three'] }],
+            });
+            assertValidPdf(result.base64 as string);
+        });
+    });
+
+    describe('generate_basic_pdf — outline / bookmarks', () => {
+        it("emits /Outlines for outline: 'auto'", async () => {
+            const result = await generateBasicPdf({
+                title: 'Outlined',
+                blocks: [
+                    { type: 'heading', text: 'Chapter 1', level: 1 },
+                    { type: 'paragraph', text: 'Body' },
+                    { type: 'pageBreak' },
+                    { type: 'heading', text: 'Chapter 2', level: 1 },
+                ],
+                outline: 'auto',
+            });
+            const text = decodedText(result.base64 as string);
+            expect(text).toContain('/Outlines');
+        });
+
+        it('emits /Outlines for an explicit bookmark tree', async () => {
+            const result = await generateBasicPdf({
+                title: 'Explicit outline',
+                blocks: [
+                    { type: 'heading', text: 'Intro', level: 1 },
+                    { type: 'pageBreak' },
+                    { type: 'heading', text: 'Details', level: 1 },
+                ],
+                outline: [
+                    { title: 'Introduction', pageIndex: 0, bold: true },
+                    { title: 'Details', pageIndex: 1, children: [{ title: 'Sub', pageIndex: 1 }] },
+                ],
+            });
+            const text = decodedText(result.base64 as string);
+            expect(text).toContain('/Outlines');
+        });
+    });
+
+    describe('generate_basic_pdf — page labels', () => {
+        it('emits /PageLabels for a roman + decimal scheme', async () => {
+            const result = await generateBasicPdf({
+                title: 'Labelled',
+                blocks: [
+                    { type: 'heading', text: 'Front matter', level: 1 },
+                    { type: 'pageBreak' },
+                    { type: 'heading', text: 'Body', level: 1 },
+                ],
+                pageLabels: [
+                    { startPage: 0, style: 'roman' },
+                    { startPage: 1, style: 'decimal', start: 1 },
+                ],
+            });
+            const text = decodedText(result.base64 as string);
+            expect(text).toContain('/PageLabels');
+        });
+    });
+
+    describe('generate_basic_pdf — viewer preferences', () => {
+        it('emits /ViewerPreferences', async () => {
+            const result = await generateBasicPdf({
+                title: 'Prefs',
+                blocks: [{ type: 'paragraph', text: 'Body' }],
+                viewerPreferences: { displayDocTitle: true, pageLayout: 'singlePage', direction: 'l2r' },
+            });
+            const text = decodedText(result.base64 as string);
+            expect(text).toContain('/ViewerPreferences');
+        });
+    });
+
+    describe('add_table — cell borders + vertical alignment', () => {
+        it('produces a valid PDF with cellBorders and cellVAlign (document backend)', async () => {
+            const result = await addTable({
+                title: 'Bordered',
+                headers: ['A', 'B'],
+                rows: [['1', '2'], ['3', '4']],
+                cellBorders: { all: true, color: '0.8 0.8 0.8', width: 0.5, style: 'solid' },
+                cellVAlign: 'middle',
+            });
+            assertValidPdf(result.base64 as string);
+        });
+
+        it('accepts viewerPreferences and stays valid', async () => {
+            const result = await addTable({
+                title: 'Prefs table',
+                headers: ['A'],
+                rows: [['1']],
+                viewerPreferences: { pageLayout: 'oneColumn' },
+            });
+            assertValidPdf(result.base64 as string);
+        });
+    });
+
+    describe('validation', () => {
+        it('rejects an outline node missing pageIndex', async () => {
+            await expect(
+                generateBasicPdf({
+                    title: 'Bad',
+                    blocks: [{ type: 'paragraph', text: 'x' }],
+                    outline: [{ title: 'No page' } as unknown as { title: string; pageIndex: number }],
+                }),
+            ).rejects.toThrow(ToolError);
+        });
+    });
+
+    describe('mapper coverage — rich optional fields', () => {
+        it('threads every optional outline / page-label / viewer-preference field', async () => {
+            const result = await generateBasicPdf({
+                title: 'Rich',
+                blocks: [
+                    { type: 'heading', text: 'A', level: 1 },
+                    { type: 'pageBreak' },
+                    { type: 'heading', text: 'B', level: 1 },
+                ],
+                outline: [
+                    {
+                        title: 'Styled',
+                        pageIndex: 0,
+                        y: 700,
+                        bold: true,
+                        italic: true,
+                        color: '#1a73e8',
+                        open: false,
+                        children: [{ title: 'Child', pageIndex: 1, italic: true }],
+                    },
+                ],
+                pageLabels: [
+                    { startPage: 0, style: 'Alpha', prefix: 'A-', start: 2 },
+                    { startPage: 1, style: 'none', prefix: 'Appendix-' },
+                ],
+                viewerPreferences: {
+                    pageLayout: 'twoColumnLeft',
+                    pageMode: 'useOutlines',
+                    hideToolbar: true,
+                    hideMenubar: true,
+                    hideWindowUI: false,
+                    fitWindow: true,
+                    centerWindow: true,
+                    displayDocTitle: true,
+                    nonFullScreenPageMode: 'useThumbs',
+                    direction: 'r2l',
+                    printScaling: 'none',
+                },
+            });
+            const text = decodedText(result.base64 as string);
+            expect(text).toContain('/Outlines');
+            expect(text).toContain('/PageLabels');
+            expect(text).toContain('/ViewerPreferences');
+        });
+
+        it('threads every per-side cell border option in add_table', async () => {
+            const result = await addTable({
+                title: 'Sides',
+                headers: ['A', 'B'],
+                rows: [['1', '2']],
+                cellBorders: { top: true, right: true, bottom: true, left: true, color: '#000000', width: 1, style: 'dashed' },
+                cellVAlign: 'bottom',
+            });
+            assertValidPdf(result.base64 as string);
+        });
+    });
+});

--- a/tests/extract-pages.test.ts
+++ b/tests/extract-pages.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Tests for `extract_pages` (pdfnative v1.4 page-tree API wrapper, single output).
+ */
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+
+import { extractPagesTool } from '../src/tools/extract-pages.js';
+import { ensureCompressionReady } from '../src/server.js';
+import { ToolError } from '../src/errors.js';
+import { assertValidPdf } from './_pdf-assert.js';
+import { makePdfBase64, makeEncryptedPdfBase64 } from './_pagetree-fixtures.js';
+
+const ENV_KEY = 'PDFNATIVE_MCP_OUTPUT_DIR';
+
+describe('extract_pages', () => {
+    beforeAll(async () => {
+        delete process.env[ENV_KEY];
+        await ensureCompressionReady();
+    });
+
+    afterEach(() => {
+        delete process.env[ENV_KEY];
+    });
+
+    it('extracts an arbitrary page subset into a single PDF', async () => {
+        const src = await makePdfBase64(5, 'Doc');
+        const result = await extractPagesTool({ pdfBase64: src, pages: [0, 2, 4] });
+        expect(result.mode).toBe('base64');
+        expect(assertValidPdf(result.base64 as string)).toBe(3);
+    });
+
+    it('preserves the requested page order (still a valid single PDF)', async () => {
+        const src = await makePdfBase64(3, 'Doc');
+        const result = await extractPagesTool({ pdfBase64: src, pages: [2, 0] });
+        expect(assertValidPdf(result.base64 as string)).toBe(2);
+    });
+
+    it('rejects an empty pages array', async () => {
+        const src = await makePdfBase64(2, 'Doc');
+        await expect(extractPagesTool({ pdfBase64: src, pages: [] })).rejects.toThrow(ToolError);
+    });
+
+    it('rejects an out-of-range page index', async () => {
+        const src = await makePdfBase64(2, 'Doc');
+        await expect(extractPagesTool({ pdfBase64: src, pages: [99] })).rejects.toThrow(ToolError);
+    });
+
+    it('rejects an encrypted source with ENCRYPTED_SOURCE', async () => {
+        const enc = makeEncryptedPdfBase64();
+        await expect(extractPagesTool({ pdfBase64: enc, pages: [0] })).rejects.toMatchObject({
+            code: 'ENCRYPTED_SOURCE',
+        });
+    });
+});

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { AddressInfo } from 'node:net';
+import { createServer as createHttpServer, request as httpRequest, type Server as HttpServer } from 'node:http';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+import { createServer } from '../src/server.js';
+
+/**
+ * DNS-rebinding / Origin protection for the optional HTTP transport.
+ *
+ * The CLI (src/cli.ts) configures the Streamable HTTP transport with
+ * `enableDnsRebindingProtection` + `allowedHosts`/`allowedOrigins` pinned to the
+ * loopback authority. These tests reproduce that wiring and assert the transport
+ * answers 403 to a foreign Host/Origin while accepting the loopback authority —
+ * matching MCP's Security Best Practices (403 on invalid Origin).
+ */
+describe('HTTP transport DNS-rebinding protection', () => {
+    let httpServer: HttpServer | undefined;
+
+    afterEach(async () => {
+        if (httpServer !== undefined) {
+            await new Promise<void>((resolve) => httpServer!.close(() => resolve()));
+            httpServer = undefined;
+        }
+    });
+
+    /** Start the MCP HTTP transport with the loopback authority (incl. port) pinned. */
+    async function startServer(): Promise<number> {
+        const mcp = createServer();
+        httpServer = createHttpServer();
+        await new Promise<void>((resolve) => httpServer!.listen(0, '127.0.0.1', () => resolve()));
+        const port = (httpServer!.address() as AddressInfo).port;
+
+        // Mirror src/cli.ts: pin Host/Origin to the loopback authority including the port.
+        const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+            enableDnsRebindingProtection: true,
+            allowedHosts: [`127.0.0.1:${port}`, `localhost:${port}`],
+            allowedOrigins: [`http://127.0.0.1:${port}`, `http://localhost:${port}`],
+        });
+        await mcp.connect(transport);
+
+        httpServer.on('request', (req, res) => {
+            if (req.url === '/mcp') {
+                void transport.handleRequest(req, res);
+            } else {
+                res.writeHead(404).end();
+            }
+        });
+        return port;
+    }
+
+    const initBody = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+    });
+
+    /** POST /mcp with a precise set of headers; resolves to the HTTP status code. */
+    function post(port: number, headers: Record<string, string>): Promise<number> {
+        return new Promise<number>((resolve, reject) => {
+            const req = httpRequest(
+                {
+                    host: '127.0.0.1',
+                    port,
+                    path: '/mcp',
+                    method: 'POST',
+                    headers: {
+                        'content-type': 'application/json',
+                        accept: 'application/json, text/event-stream',
+                        'content-length': Buffer.byteLength(initBody),
+                        ...headers,
+                    },
+                },
+                (res) => {
+                    res.resume();
+                    res.on('end', () => resolve(res.statusCode ?? 0));
+                },
+            );
+            req.on('error', reject);
+            req.end(initBody);
+        });
+    }
+
+    it('rejects a foreign Host header with 403', async () => {
+        const port = await startServer();
+        expect(await post(port, { host: 'evil.example.com' })).toBe(403);
+    });
+
+    it('rejects a foreign Origin header with 403', async () => {
+        const port = await startServer();
+        expect(await post(port, { host: `127.0.0.1:${port}`, origin: 'http://evil.example.com' })).toBe(403);
+    });
+
+    it('accepts the loopback Host/Origin', async () => {
+        const port = await startServer();
+        const status = await post(port, { host: `127.0.0.1:${port}`, origin: `http://127.0.0.1:${port}` });
+        expect(status).not.toBe(403);
+        expect(status).toBeLessThan(400);
+    });
+});

--- a/tests/merge-pdfs.test.ts
+++ b/tests/merge-pdfs.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for `merge_pdfs` (pdfnative v1.4 page-tree API wrapper).
+ */
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { mergePdfsTool } from '../src/tools/merge-pdfs.js';
+import { ensureCompressionReady } from '../src/server.js';
+import { ToolError } from '../src/errors.js';
+import { assertValidPdf } from './_pdf-assert.js';
+import { makePdfBase64, makeEncryptedPdfBase64 } from './_pagetree-fixtures.js';
+
+const ENV_KEY = 'PDFNATIVE_MCP_OUTPUT_DIR';
+
+describe('merge_pdfs', () => {
+    beforeAll(async () => {
+        delete process.env[ENV_KEY];
+        await ensureCompressionReady();
+    });
+
+    afterEach(() => {
+        delete process.env[ENV_KEY];
+    });
+
+    it('concatenates two PDFs into one with the combined page count', async () => {
+        const a = await makePdfBase64(2, 'A');
+        const b = await makePdfBase64(3, 'B');
+        const result = await mergePdfsTool({ pdfsBase64: [a, b] });
+        expect(result.mode).toBe('base64');
+        const pages = assertValidPdf(result.base64 as string);
+        expect(pages).toBe(5);
+    });
+
+    it('accepts dropAnnotations and still produces a valid PDF', async () => {
+        const a = await makePdfBase64(1, 'A');
+        const b = await makePdfBase64(1, 'B');
+        const result = await mergePdfsTool({ pdfsBase64: [a, b], dropAnnotations: true });
+        assertValidPdf(result.base64 as string, 2);
+    });
+
+    it('rejects fewer than two sources', async () => {
+        const a = await makePdfBase64(1, 'A');
+        await expect(mergePdfsTool({ pdfsBase64: [a] })).rejects.toThrow(ToolError);
+    });
+
+    it('rejects more than fifty sources', async () => {
+        const a = await makePdfBase64(1, 'A');
+        const many = Array.from({ length: 51 }, () => a);
+        await expect(mergePdfsTool({ pdfsBase64: many })).rejects.toThrow(ToolError);
+    });
+
+    it('rejects an encrypted source with ENCRYPTED_SOURCE', async () => {
+        const a = await makePdfBase64(1, 'A');
+        const enc = makeEncryptedPdfBase64();
+        await expect(mergePdfsTool({ pdfsBase64: [a, enc] })).rejects.toMatchObject({
+            code: 'ENCRYPTED_SOURCE',
+        });
+    });
+
+    it('enforces a tiny maxOutputSizeBytes with OUTPUT_TOO_LARGE', async () => {
+        const a = await makePdfBase64(2, 'A');
+        const b = await makePdfBase64(2, 'B');
+        await expect(mergePdfsTool({ pdfsBase64: [a, b], maxOutputSizeBytes: 64 })).rejects.toMatchObject({
+            code: 'OUTPUT_TOO_LARGE',
+        });
+    });
+
+    it('writes to a sandboxed file when outputMode=file', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pdfnative-merge-'));
+        process.env[ENV_KEY] = dir;
+        const a = await makePdfBase64(1, 'A');
+        const b = await makePdfBase64(1, 'B');
+        const result = await mergePdfsTool({ pdfsBase64: [a, b], outputMode: 'file', outputPath: 'merged.pdf' });
+        expect(result.mode).toBe('file');
+        expect(result.filePath?.startsWith(dir)).toBe(true);
+        const bytes = await fs.readFile(result.filePath as string);
+        assertValidPdf(new Uint8Array(bytes), 2);
+    });
+});

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { emitPdf, resolveSandboxedPath, getOutputSandbox } from '../src/output.js';
+import { emitPdf, emitPdfMulti, resolveSandboxedPath, getOutputSandbox } from '../src/output.js';
 import { SecurityError, ToolError } from '../src/errors.js';
 
 const ENV_KEY = 'PDFNATIVE_MCP_OUTPUT_DIR';
@@ -56,6 +56,51 @@ describe('output sandbox', () => {
         delete process.env[ENV_KEY];
         expect(getOutputSandbox()).toBeNull();
         await expect(emitPdf(new Uint8Array([1]), { mode: 'file', outputPath: 'a.pdf' })).rejects.toThrow(SecurityError);
+    });
+});
+
+describe('emitPdfMulti', () => {
+    const ENV = 'PDFNATIVE_MCP_OUTPUT_DIR';
+    let sandboxDir: string;
+
+    beforeEach(async () => {
+        sandboxDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pdfnative-multi-'));
+    });
+
+    afterEach(() => {
+        delete process.env[ENV];
+    });
+
+    it('returns a base64 part per PDF with a size recap', async () => {
+        delete process.env[ENV];
+        const result = await emitPdfMulti([new Uint8Array([1, 2]), new Uint8Array([3, 4, 5])], { mode: 'base64' });
+        expect(result.mode).toBe('base64');
+        expect(result.count).toBe(2);
+        expect(result.totalBytes).toBe(5);
+        expect(result.parts.map((p) => p.index)).toEqual([0, 1]);
+        expect(typeof result.parts[0]?.base64).toBe('string');
+        expect(result.parts[1]?.sizeBytes).toBe(3);
+    });
+
+    it('writes 1-based indexed files inside the sandbox', async () => {
+        process.env[ENV] = sandboxDir;
+        const result = await emitPdfMulti([new Uint8Array([0x25]), new Uint8Array([0x50])], {
+            mode: 'file',
+            outputPath: 'doc.pdf',
+        });
+        expect(result.mode).toBe('file');
+        expect(result.parts[0]?.filePath?.endsWith('doc-1.pdf')).toBe(true);
+        expect(result.parts[1]?.filePath?.endsWith('doc-2.pdf')).toBe(true);
+        for (const part of result.parts) {
+            const written = await fs.readFile(part.filePath as string);
+            expect(written.length).toBe(1);
+        }
+    });
+
+    it('rejects when a part exceeds the per-PDF cap', async () => {
+        delete process.env[ENV];
+        const huge = new Uint8Array(51 * 1024 * 1024);
+        await expect(emitPdfMulti([huge], { mode: 'base64' })).rejects.toThrow(ToolError);
     });
 });
 

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -14,11 +14,20 @@ describe('server', () => {
 
     it('exposes stable metadata', () => {
         expect(__serverMetadata.name).toBe('pdfnative-mcp');
-        expect(__serverMetadata.version).toBe('1.2.0');
+        expect(__serverMetadata.version).toBe('1.3.0');
+    });
+
+    it('advertises a human-readable title and description in serverInfo (MCP Implementation)', () => {
+        // 2025-11-25 added Implementation.description to mirror server.json; hosts and
+        // the MCP registry surface it during initialization.
+        expect(typeof __serverMetadata.title).toBe('string');
+        expect(__serverMetadata.title.length).toBeGreaterThan(0);
+        expect(__serverMetadata.description).toMatch(/MCP server/i);
+        expect(__serverMetadata.description).toMatch(/17 tools/);
     });
 
     it('SERVER_INSTRUCTIONS advertises decision tree and pitfalls for AI clients', () => {
-        expect(__serverInstructions).toMatch(/pdfnative.*v1\.3/);
+        expect(__serverInstructions).toMatch(/pdfnative.*v1\.4/);
         expect(__serverInstructions).toContain('DECISION TREE');
         expect(__serverInstructions).toContain('COMMON PITFALLS');
         // Cite each tool by name in the decision tree.
@@ -26,7 +35,7 @@ describe('server', () => {
             'generate_basic_pdf', 'add_barcode', 'add_international_text', 'add_table',
             'add_form', 'embed_image', 'prepare_signature_placeholder', 'sign_pdf',
             'verify_pdf', 'validate_pdf', 'inspect_pdf', 'add_attachment', 'extract_text',
-            'extract_attachments',
+            'extract_attachments', 'merge_pdfs', 'split_pdf', 'extract_pages',
         ]) {
             expect(__serverInstructions).toContain(t);
         }
@@ -50,20 +59,58 @@ describe('server', () => {
             'add_table',
             'embed_image',
             'extract_attachments',
+            'extract_pages',
             'extract_text',
             'generate_basic_pdf',
             'inspect_pdf',
+            'merge_pdfs',
             'prepare_signature_placeholder',
             'sign_pdf',
+            'split_pdf',
             'validate_pdf',
             'verify_pdf',
         ]);
 
         // Every tool advertises _meta.apiVersion and at least one example.
         for (const t of response.tools) {
-            expect(t._meta?.apiVersion).toBe('1.2.0');
+            expect(t._meta?.apiVersion).toBe('1.3.0');
             expect(Array.isArray(t._meta?.examples)).toBe(true);
             expect((t._meta?.examples ?? []).length).toBeGreaterThan(0);
+        }
+    });
+
+    it('tool input schemas are JSON Schema 2020-12 compatible (dialect-agnostic)', async () => {
+        // 2025-11-25 (SEP-1613) establishes JSON Schema 2020-12 as the default dialect
+        // when `$schema` is omitted. Our hand-written schemas stay dialect-agnostic by
+        // avoiding constructs whose meaning changed across drafts ($ref/$defs/definitions,
+        // draft-04 boolean exclusiveMinimum/Maximum, draft-07 dependencies). This guard
+        // fails if any tool reintroduces a dialect-sensitive keyword.
+        const server = createServer() as unknown as { _requestHandlers: Map<string, (req: unknown) => Promise<unknown>> };
+        const listHandler = server._requestHandlers.get('tools/list');
+        const response = (await listHandler!({ method: 'tools/list', params: {} })) as {
+            tools: Array<{ name: string; inputSchema: Record<string, unknown>; outputSchema?: Record<string, unknown> }>;
+        };
+
+        const FORBIDDEN = new Set(['$ref', '$defs', 'definitions', 'dependencies']);
+        const scan = (node: unknown, toolName: string, at: string): void => {
+            if (Array.isArray(node)) {
+                node.forEach((v, i) => scan(v, toolName, `${at}[${i}]`));
+                return;
+            }
+            if (node === null || typeof node !== 'object') return;
+            for (const [key, value] of Object.entries(node)) {
+                expect(FORBIDDEN.has(key), `${toolName}${at}.${key} is dialect-sensitive`).toBe(false);
+                // Draft-04 allowed boolean exclusiveMinimum/Maximum; 2020-12 requires a number.
+                if ((key === 'exclusiveMinimum' || key === 'exclusiveMaximum') && typeof value === 'boolean') {
+                    throw new Error(`${toolName}${at}.${key} uses the draft-04 boolean form`);
+                }
+                scan(value, toolName, `${at}.${key}`);
+            }
+        };
+
+        for (const t of response.tools) {
+            scan(t.inputSchema, t.name, '.inputSchema');
+            if (t.outputSchema !== undefined) scan(t.outputSchema, t.name, '.outputSchema');
         }
     });
 

--- a/tests/sign-pdf-provider.test.ts
+++ b/tests/sign-pdf-provider.test.ts
@@ -1,0 +1,73 @@
+/**
+ * End-to-end tests for constant-time signing via the node:crypto provider
+ * (v1.3.0). Uses real self-signed cert fixtures and the real `sign_pdf` /
+ * `verify_pdf` tools (NO pdfnative mock), so the node:crypto signing path and
+ * the pure-JS fallback are both exercised against actual CMS verification.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { signPdf } from '../src/tools/sign-pdf.js';
+import { verifyPdf } from '../src/tools/verify-pdf.js';
+import { generateBasicPdf } from '../src/tools/generate-basic-pdf.js';
+import { ensureCompressionReady } from '../src/server.js';
+import { buildRsaSelfSignedCert, buildEcdsaSelfSignedCert } from './_cert-fixtures.js';
+
+const ENV_KEY = 'PDFNATIVE_MCP_OUTPUT_DIR';
+
+function toB64(bytes: Uint8Array): string {
+    return Buffer.from(bytes).toString('base64');
+}
+
+async function makePdfToSign(): Promise<string> {
+    const result = await generateBasicPdf({ title: 'To sign', blocks: [{ type: 'paragraph', text: 'Sign me' }] });
+    return result.base64 as string;
+}
+
+describe('sign_pdf — node:crypto provider (constant-time)', () => {
+    beforeAll(async () => {
+        delete process.env[ENV_KEY];
+        await ensureCompressionReady();
+    });
+
+    it('signs with an RSA PKCS#1 DER key via node:crypto and verifies', async () => {
+        const { certDer, privateKey } = buildRsaSelfSignedCert();
+        const rsaDer = new Uint8Array(privateKey.export({ format: 'der', type: 'pkcs1' }));
+        const signed = await signPdf({
+            pdfBase64: await makePdfToSign(),
+            algorithm: 'rsa-sha256',
+            certDerBase64: toB64(certDer),
+            rsaKeyPkcs1DerBase64: toB64(rsaDer),
+            signerName: 'Alice',
+        });
+        const verified = await verifyPdf({ pdfBase64: signed.base64 as string });
+        expect(verified.allValid).toBe(true);
+        expect(verified.signatureCount).toBe(1);
+    });
+
+    it('signs with an ECDSA P-256 PKCS#8 DER key via node:crypto and verifies', async () => {
+        const { certDer, privateKey } = buildEcdsaSelfSignedCert();
+        const ecDer = new Uint8Array(privateKey.export({ format: 'der', type: 'pkcs8' }));
+        const signed = await signPdf({
+            pdfBase64: await makePdfToSign(),
+            algorithm: 'ecdsa-sha256',
+            certDerBase64: toB64(certDer),
+            ecPrivateKeyDerBase64: toB64(ecDer),
+        });
+        const verified = await verifyPdf({ pdfBase64: signed.base64 as string });
+        expect(verified.allValid).toBe(true);
+        expect(verified.signatureCount).toBe(1);
+    });
+
+    it('signs with a raw P-256 scalar (pure-JS fallback) and verifies', async () => {
+        const { certDer, ecKey } = buildEcdsaSelfSignedCert();
+        const scalarHex = ecKey.d.toString(16).padStart(64, '0');
+        const signed = await signPdf({
+            pdfBase64: await makePdfToSign(),
+            algorithm: 'ecdsa-sha256',
+            certDerBase64: toB64(certDer),
+            ecPrivateScalarHex: scalarHex,
+        });
+        const verified = await verifyPdf({ pdfBase64: signed.base64 as string });
+        expect(verified.allValid).toBe(true);
+    });
+});

--- a/tests/split-pdf.test.ts
+++ b/tests/split-pdf.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for `split_pdf` (pdfnative v1.4 page-tree API wrapper, multi-output).
+ */
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { splitPdfTool } from '../src/tools/split-pdf.js';
+import { ensureCompressionReady } from '../src/server.js';
+import { ToolError } from '../src/errors.js';
+import { assertValidPdf } from './_pdf-assert.js';
+import { makePdfBase64, makeEncryptedPdfBase64 } from './_pagetree-fixtures.js';
+
+const ENV_KEY = 'PDFNATIVE_MCP_OUTPUT_DIR';
+
+describe('split_pdf', () => {
+    beforeAll(async () => {
+        delete process.env[ENV_KEY];
+        await ensureCompressionReady();
+    });
+
+    afterEach(() => {
+        delete process.env[ENV_KEY];
+    });
+
+    it('splits a PDF into one document per range', async () => {
+        const src = await makePdfBase64(4, 'Doc');
+        const result = await splitPdfTool({ pdfBase64: src, ranges: [{ start: 0 }, { start: 1, end: 3 }] });
+        expect(result.mode).toBe('base64');
+        expect(result.count).toBe(2);
+        expect(result.parts).toHaveLength(2);
+        expect(assertValidPdf(result.parts[0]!.base64 as string)).toBe(1);
+        expect(assertValidPdf(result.parts[1]!.base64 as string)).toBe(3);
+        expect(result.totalBytes).toBeGreaterThan(0);
+    });
+
+    it('treats a range without end as a single page', async () => {
+        const src = await makePdfBase64(3, 'Doc');
+        const result = await splitPdfTool({ pdfBase64: src, ranges: [{ start: 2 }] });
+        expect(result.count).toBe(1);
+        expect(assertValidPdf(result.parts[0]!.base64 as string)).toBe(1);
+    });
+
+    it('rejects a range whose end precedes its start', async () => {
+        const src = await makePdfBase64(3, 'Doc');
+        await expect(splitPdfTool({ pdfBase64: src, ranges: [{ start: 2, end: 1 }] })).rejects.toThrow(ToolError);
+    });
+
+    it('rejects an empty ranges array', async () => {
+        const src = await makePdfBase64(2, 'Doc');
+        await expect(splitPdfTool({ pdfBase64: src, ranges: [] })).rejects.toThrow(ToolError);
+    });
+
+    it('rejects an encrypted source with ENCRYPTED_SOURCE', async () => {
+        const enc = makeEncryptedPdfBase64();
+        await expect(splitPdfTool({ pdfBase64: enc, ranges: [{ start: 0 }] })).rejects.toMatchObject({
+            code: 'ENCRYPTED_SOURCE',
+        });
+    });
+
+    it('writes one indexed file per range when outputMode=file', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pdfnative-split-'));
+        process.env[ENV_KEY] = dir;
+        const src = await makePdfBase64(3, 'Doc');
+        const result = await splitPdfTool({
+            pdfBase64: src,
+            ranges: [{ start: 0 }, { start: 1, end: 2 }],
+            outputMode: 'file',
+            outputPath: 'part.pdf',
+        });
+        expect(result.mode).toBe('file');
+        expect(result.count).toBe(2);
+        expect(result.parts[0]!.filePath?.endsWith('part-1.pdf')).toBe(true);
+        expect(result.parts[1]!.filePath?.endsWith('part-2.pdf')).toBe(true);
+        for (const part of result.parts) {
+            const bytes = await fs.readFile(part.filePath as string);
+            assertValidPdf(new Uint8Array(bytes));
+        }
+    });
+});


### PR DESCRIPTION
…ime signing

- feat(tools): add merge_pdfs — concatenate 2-50 PDFs via page-tree API
- feat(tools): add split_pdf — split into per-range documents (MultiOutputResult)
- feat(tools): add extract_pages — pull arbitrary page subset into one PDF
- feat(tools): generate_basic_pdf gains outline, pageLabels, nested lists, viewerPreferences
- feat(tools): add_table gains cellBorders, cellVAlign, viewerPreferences
- feat(tools): add_international_text gains viewerPreferences
- feat(signing): constant-time node:crypto provider (RSA/ECDSA-P256) with pure-JS fallback
- feat(output): emitPdfMulti + MultiOutputResult/MultiOutputPart (50 MiB/part, 200 MiB aggregate)
- feat(security): HTTP transport DNS-rebinding protection (Host/Origin pinned to loopback → 403)
- feat(server): serverInfo title + description (MCP Implementation metadata)
- chore(deps): pdfnative ^1.3.0 → ^1.4.0; @modelcontextprotocol/sdk ^1.29
- chore(meta): version 1.3.0, apiVersion 1.3.0, SERVER_VERSION 1.3.0
- chore(keywords): add merge-pdf, split-pdf, extract-pages, pdf-manipulation, pdf-bookmarks, pdf-outline, page-labels, viewer-preferences keywords to package.json
- docs: README, AGENTS.md, AI_GUIDE, KNOWLEDGE_BASE, API_STABILITY, ROADMAP, llms.txt refreshed
- test: merge-pdfs, split-pdf, extract-pages, crypto-provider, sign-pdf-provider, doc-features, http-transport test suites; JSON Schema 2020-12 dialect guard

# PR: v1.3.0 — page-tree tools, pdfnative 1.4 features, constant-time signing

## Summary

A minor, fully backward-compatible release that extends pdfnative-mcp to **17 tools** and threads the new [pdfnative v1.4.0](https://github.com/Nizoka/pdfnative) capabilities through the server. Adds three **page-tree tools** — `merge_pdfs`, `split_pdf`, `extract_pages` — finally unblocking the long-deferred roadmap items now that pdfnative exports a safe page-tree API. Threads pdfnative 1.4's **document features** (bookmarks/`outline`, `pageLabels`, nested `list` items, `viewerPreferences`, table `cellBorders`/`cellVAlign`) into the authoring tools, and hardens `sign_pdf` with a per-call constant-time **`node:crypto` signature provider** (transparent pure-JS fallback). No breaking changes — all v1.2.0 tool calls work unchanged and default responses are byte-identical.

Full notes: [`release-notes/v1.3.0.md`](../../release-notes/v1.3.0.md).

## Scope

| Phase | Subject |
| --- | --- |
| 0 | Branch + version bump (package.json `1.3.0`, pdfnative pin `^1.4.0`) |
| 1 | Page-tree tools: `emitPdfMulti` + `MultiOutputResult` (`src/output.ts`), `src/pagetree.ts` error mapping, `merge_pdfs`, `split_pdf`, `extract_pages` |
| 2 | Document features: `src/doc-features.ts` (outline / page labels / viewer prefs / nested lists) threaded into `generate_basic_pdf`, `add_table` (`cellBorders`/`cellVAlign`), `add_international_text` |
| 3 | Constant-time signing: `src/crypto-provider.ts` (`node:crypto`) wired into `sign_pdf` with pure-JS fallback |
| 4 | Server registration (3 tools, `MULTI_PDF_OUTPUT_SCHEMA`, dispatch, `SERVER_VERSION`/`apiVersion` → 1.3.0, decision tree); `index.ts`, `server.json` |
| 5 | Tests: page-tree fixtures + 6 new suites + extended `output.test.ts`; `server.test.ts` → 17 tools / 1.3.0 |
| 6 | Examples: `merge-pdfs`, `split-pdf`, `extract-pages`, `bookmarked-report`, `bordered-table` |
| 7 | Docs: README, AGENTS.md, AI_GUIDE, API_STABILITY, KNOWLEDGE_BASE, LOCAL_TESTING, ROADMAP, llms.txt, copilot-instructions |
| 8 | Security & spec alignment: HTTP DNS-rebinding protection (cli.ts), `serverInfo` title/description (server.ts), JSON-Schema-2020-12 dialect guard, MCP-2025-11-25 protocol notes |
| 9 | Release: `release-notes/v1.3.0.md`, CHANGELOG mirror, this PR draft |

## Closes

- Roadmap: ships the previously **blocked-upstream** page-tree tools `merge_pdfs`, `split_pdf`, plus the new `extract_pages` (pdfnative v1.4.0 page-tree export API).
- `redact_pdf` and an encrypted-PDF round-trip remain deferred (blocked on upstream pdfnative content-redaction / Standard Security Handler writer APIs).

## Quality gate

- ✅ `npm run typecheck:all` — 0 errors
- ✅ `npm run lint` — 0 errors (36 pre-existing non-null-assertion warnings in untouched files)
- ✅ `npm run test:coverage` — **306 tests** passing; **89.96** stmts / **78.85** branches / **95.43** funcs / **92.14** lines (≥ vitest thresholds 88 / 75 / 85 / 90)
- ✅ `npm run build` — clean `dist/`
- ✅ `npm run examples:check` — every `examples/*.json` references a live tool; self-contained examples execute and pass `assertValidPdf`

## Changes summary

### Added
- **Tool `merge_pdfs`** (new, 15th) — concatenate 2–50 PDFs (`pdfsBase64[]`) into one via pdfnative's page-tree API. Optional `dropAnnotations`/`maxOutputSizeBytes`; standard `outputMode`/`outputPath`. Encrypted sources → `ENCRYPTED_SOURCE`; oversize output → `OUTPUT_TOO_LARGE` (shared `src/pagetree.ts`).
- **Tool `split_pdf`** (new, 16th) — split one PDF into one document per page range (`ranges: [{ start, end? }]`, 0-based inclusive; `end` defaults to `start`, validated `end >= start`). Returns the new `MultiOutputResult` (`{ mode, count, totalSizeBytes, parts[] }`); file mode writes indexed paths (`report.pdf` → `report-1.pdf`, …).
- **Tool `extract_pages`** (new, 17th) — pull an arbitrary page subset (`pages: number[]`, 0-based, max 5000, order preserved) into a single PDF.
- **`generate_basic_pdf`** — optional `outline` (`'auto'` or explicit `[{ title, pageIndex, children?, open? }]` tree, depth ≤ 6), `pageLabels` (`[{ startPage, style?, prefix?, start? }]`), nested `list` items (`{ text, items?, style? }`, depth ≤ 6), and `viewerPreferences`.
- **`add_table`** — optional `cellBorders` ({ top?, right?, bottom?, left?, color?, width? }), `cellVAlign` (`'top'|'middle'|'bottom'`), and `viewerPreferences` (any forces the document backend).
- **`add_international_text`** — optional `viewerPreferences`.
- **`src/crypto-provider.ts`** — `buildNodeCryptoProvider()` returns a per-call `node:crypto` `CryptoProvider` (RSA PKCS#1/PKCS#8; ECDSA P-256 SEC1/PKCS#8, DER signatures), or `null` on import failure.
- **`src/output.ts`** — `emitPdfMulti()` + `MultiOutputResult`/`MultiOutputPart` (per-part 50 MiB cap, 200 MiB aggregate); `indexedOutputPath()` helper.
- **`src/doc-features.ts`** — shared Zod schemas + mappers (nested lists, outline, page labels, viewer preferences) reused across authoring tools.
- **`src/pagetree.ts`** — `mapPageTreeError()` centralises page-tree error mapping.
- **Security (HTTP transport):** the optional Streamable HTTP transport (`PDFNATIVE_MCP_PORT`) enables DNS-rebinding protection — `enableDnsRebindingProtection` + `allowedHosts`/`allowedOrigins` pinned to the loopback authority; foreign `Host`/`Origin` → **403** (MCP Security Best Practices). stdio unaffected.
- **`serverInfo` metadata:** advertises `title` + `description` (MCP `Implementation`, mirroring `server.json`).
- **Examples** — `merge-pdfs.json`, `split-pdf.json`, `extract-pages.json`, `bookmarked-report.json`, `bordered-table.json` (executable, guarded by examples-as-tests).
- **Tests** — `merge-pdfs.test.ts`, `split-pdf.test.ts`, `extract-pages.test.ts`, `crypto-provider.test.ts`, `sign-pdf-provider.test.ts`, `doc-features.test.ts`, `http-transport.test.ts` (DNS-rebinding 403), a JSON-Schema-2020-12 dialect guard + `serverInfo` metadata assertions in `server.test.ts`, `_pagetree-fixtures.ts`; extended `output.test.ts`.

### Changed
- **Dependency:** `pdfnative` `^1.3.0` → `^1.4.0` (additive — page-tree, outline, page-label, viewer-preference, nested-list, cell-border APIs).
- **Signing:** RSA and EC-DER paths sign through the `node:crypto` provider (constant-time) with a transparent pure-JS fallback when key import fails; the raw-scalar `ecPrivateScalarHex` path stays pure-JS. Produced signatures are interoperable and verify identically with `verify_pdf`.
- **MCP `_meta.apiVersion`** bumped `1.2.0` → `1.3.0` on every tool; `SERVER_VERSION` and `server.json` versions → `1.3.0`.
- **Server:** `SERVER_INSTRUCTIONS` decision tree extended to 17 tools (combine/carve branch + page-tree, signing, nested-list pitfalls); new `MULTI_PDF_OUTPUT_SCHEMA` advertised for `split_pdf`; `dispatchOutput` handles the multi-output shape first.
- **Tool count assertion** in `tests/server.test.ts` — 14 → 17.
- **MCP protocol alignment:** built on `@modelcontextprotocol/sdk` ^1.29, which negotiates the latest **2025-11-25** revision (fallback `2025-06-18`/`2025-03-26`); tool schemas are JSON Schema 2020-12 (dialect-agnostic); `merge_pdfs`' `maxOutputSizeBytes` documented as the in-memory assembly guard (distinct from the 50 MiB emit cap).
- **Docs:** README, `AGENTS.md`, `docs/AI_GUIDE.md`, `docs/API_STABILITY.md`, `docs/KNOWLEDGE_BASE.md`, `docs/guides/LOCAL_TESTING.md`, `ROADMAP.md`, `llms.txt`, and `.github/copilot-instructions.md` refreshed for the 17-tool / pdfnative-1.4 surface + protocol alignment.

## Deferred (with rationale)

- **`redact_pdf`** — pdfnative does not yet export an annotation read/write or content-stream redaction API. Building it on raw primitives would be production-unsafe. Blocked upstream.
- **Encrypted-PDF round-trip fixtures** — once pdfnative exposes a Standard Security Handler writer.
- **Per-tool HTTP page-by-page streaming** — once MCP allows partial `structuredContent` envelopes.

## Reviewer checklist

- [x] CHANGELOG.md v1.3.0 entry mirrors `release-notes/v1.3.0.md`
- [x] `package.json` version === `server.json` versions === `SERVER_VERSION` === `1.3.0`
- [x] Tool count assertion in `tests/server.test.ts` equals 17; list includes `merge_pdfs`, `split_pdf`, `extract_pages`
- [x] Every tool exposes `_meta.apiVersion === '1.3.0'` and a non-empty `_meta.examples` array
- [x] Page-tree tools reject encrypted sources with `ENCRYPTED_SOURCE`; oversize output → `OUTPUT_TOO_LARGE`
- [x] `split_pdf` returns the multi-output shape `{ mode, count, totalSizeBytes, parts[] }`; file mode writes indexed paths
- [x] `outline` / `pageLabels` / nested `list` items / `viewerPreferences` produce the expected catalog entries; omitting them = byte-identical output
- [x] `add_table` `cellBorders` / `cellVAlign` force the document backend; default output unchanged
- [x] `sign_pdf` constant-time `node:crypto` path verifies identically with `verify_pdf`; pure-JS fallback path covered (RSA PKCS#1, EC PKCS#8/SEC1, raw scalar)
- [x] `SERVER_INSTRUCTIONS` decision tree lists 17 tools incl. the combine/carve branch
- [x] HTTP transport rejects a foreign `Host`/`Origin` with **403** and accepts the loopback authority (covered by `http-transport.test.ts`)
- [x] `serverInfo` advertises `title` + `description`; tool schemas pass the JSON-Schema-2020-12 dialect guard
- [x] `server.json` validates against the MCP registry schema
- [x] No `any` added in `src/`; no new CodeQL alerts
- [x] Test coverage ≥ vitest thresholds (88 / 75 / 85 / 90)

## Notes for the merger

- No breaking changes; minor bump per [`docs/API_STABILITY.md`](../../docs/API_STABILITY.md) §3 (new tools + new optional inputs).
- Publish is via GitHub Actions Trusted Publishing (OIDC) — no `NPM_TOKEN`.
- GitHub Release title: `v1.3.0 — page-tree tools, pdfnative 1.4 features, constant-time signing`.
