### PR TITLE
Release/v1.4.0

### DIFF
--- a/.github/AGENT_RULES.md
+++ b/.github/AGENT_RULES.md
@@ -1,0 +1,97 @@
+# AI Agent Instructions for pdfnative-mcp
+
+> Machine-readable companion: [.github/ai-governance.json](ai-governance.json).
+> Narrative walk-through: [docs/guides/AI_GOVERNANCE.md](../docs/guides/AI_GOVERNANCE.md).
+> This file is the human-and-agent-readable protocol every coding agent
+> (Copilot, Cursor, Claude, Antigravity, Aider, Cline, Windsurf, Gemini CLI, …)
+> **must** follow before proposing an issue, pull request, or dependency change
+> for `pdfnative-mcp` (and the wider `pdfnative` family).
+
+You are an AI assistant helping a user develop or fix `pdfnative-mcp`. You act as
+a **draftsman**, never as an autonomous submitter. The server itself embodies
+this rule: it exposes a `draft_governance_issue` tool that produces a *local*,
+governance-compliant draft plus a compliance report — and contains **no code
+path that can write to GitHub or make any outbound network call.**
+
+## Mandatory pre-issue rules
+
+1. **Zero runtime dependencies.** Never suggest, add, or import an external npm
+   package for a runtime feature. `pdfnative-mcp` ships only `pdfnative`, the MCP
+   SDK, and `zod`. Zero-additional-dependency is a **non-negotiable blocker** for
+   any enhancement request. Dev-only tooling changes require explicit human
+   justification.
+2. **No duplicates.** Search open *and* closed issues/PRs before proposing
+   anything. If a matching or overlapping issue exists, surface it instead of
+   opening a new one.
+3. **Local validation & reproduction.** Create and **execute** a minimal
+   reproduction (an MCP tool call or a Node/TS snippet) locally. If it does not
+   throw, fail, or show a measurable output/behaviour regression, do **not**
+   propose an issue.
+4. **Byte-identity & schema awareness.** For changes touching a tool, confirm the
+   change is additive and that default inputs keep producing byte-identical
+   output; keep the hand-written JSON Schema and the Zod schema aligned. Report
+   any intentional byte/schema changes.
+5. **Human-in-the-loop gate (ethics).** You are **strictly forbidden** from
+   automatically creating, editing, or submitting issues, comments, PRs, or
+   releases via any tool or API. Produce a local markdown draft in
+   [.github/drafts/](drafts/) (the `draft_governance_issue` tool does this for
+   you) and present it to the user together with a **compliance report**. The
+   user must explicitly approve and trigger any submission.
+6. **Identity integrity.** Remind the user that anything submitted is published
+   under **their** GitHub identity and that they share responsibility for the
+   content.
+
+## Human-in-the-loop workflow
+
+```
+[Agent detects bug/improvement]
+            │
+            ▼
+ [Local validation & reproduction]
+            │
+            ▼
+[Verify zero-dependency constraint]
+            │
+            ▼
+ [draft_governance_issue → draft markdown in .github/drafts/ + compliance report]
+            │
+            ▼
+[Present draft + compliance report to user]
+            │
+            ▼
+ [User explicitly reviews & signs off]   ◄─── CRITICAL ETHICAL GATE
+            │
+            ▼
+ [User manually submits or approves the API call]
+```
+
+## Compliance report (present with every draft)
+
+The `draft_governance_issue` tool returns these fields in `structuredContent`;
+present them verbatim:
+
+- **zero_dependency_confirmed** — no new runtime dependency introduced.
+- **reproduction_command** — the exact command / tool call you ran.
+- **reproduction_result** — the observed failure/regression.
+- **duplicate_search_performed** — you searched open and closed issues.
+- **affected_packages** — which packages are impacted.
+- **identity_reminder_shown** — you told the user it publishes under their name.
+
+## Validate a draft before presenting it
+
+```bash
+npm run verify:issue -- .github/drafts/my-issue.md
+```
+
+The verifier fails when the draft proposes an external runtime dependency or
+omits a reproduction code block. A passing check is **necessary but not
+sufficient** — the human review gate above always applies.
+
+## What agents must NOT do
+
+- Add a runtime dependency.
+- Open, edit, label, close, or comment on issues/PRs autonomously.
+- Make any outbound network call or emit telemetry from the server.
+- Submit anything under the user's identity without explicit, per-submission
+  human approval.
+- Bypass local validation or duplicate checks.

--- a/.github/ai-governance.json
+++ b/.github/ai-governance.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "pdfnative-mcp AI Governance Configuration",
+  "description": "Machine-readable contract governing how AI coding agents may propose issues, contributions, and changes for pdfnative-mcp. Agents that scan repository configuration on initialization MUST honour this file. See .github/AGENT_RULES.md for the human-and-agent-readable protocol. This contract also backs the `draft_governance_issue` MCP tool, which produces local, compliant issue drafts and NEVER submits them.",
+  "version": "1.0.0",
+  "spec_updated": "2026-07-05",
+  "applies_to": [
+    "pdfnative",
+    "pdfnative-cli",
+    "pdfnative-mcp",
+    "pdfnative-react"
+  ],
+  "policy": {
+    "automatic_issue_reporting": false,
+    "runtime_dependencies_allowed": false,
+    "human_in_the_loop_mandatory": true,
+    "autonomous_github_writes_allowed": false,
+    "outbound_network_allowed": false,
+    "telemetry_allowed": false,
+    "required_issue_fields": [
+      "minimal_reproduction",
+      "environment",
+      "expected_behavior"
+    ]
+  },
+  "human_in_the_loop": {
+    "role_of_agent": "draftsman",
+    "gate": "A human MUST explicitly review, sign off on, and trigger any GitHub issue, comment, PR, or release. The agent's authority ends at producing a local draft plus a compliance report. The pdfnative-mcp server contains NO code path that can write to GitHub or make any outbound network call.",
+    "identity_integrity": "Any issue or PR is published under the human user's GitHub identity. The agent MUST remind the user of their shared responsibility for the content before submission.",
+    "draft_location": ".github/drafts/"
+  },
+  "pre_issue_checklist": [
+    "no_duplicate_open_or_closed_issue",
+    "zero_runtime_dependency_preserved",
+    "local_minimal_reproduction_executed",
+    "expected_vs_actual_documented",
+    "environment_captured"
+  ],
+  "compliance_report": {
+    "description": "The structured summary an agent MUST present to the user alongside every draft. The `draft_governance_issue` tool returns exactly these fields in its structuredContent.",
+    "required_fields": [
+      "zero_dependency_confirmed",
+      "reproduction_command",
+      "reproduction_result",
+      "duplicate_search_performed",
+      "affected_packages",
+      "identity_reminder_shown"
+    ]
+  },
+  "capability_manifest": {
+    "description": "Authoritative project context an agent SHOULD load before proposing changes.",
+    "sources": [
+      "AGENTS.md",
+      ".github/copilot-instructions.md",
+      ".github/AGENT_RULES.md",
+      "docs/guides/AI_GOVERNANCE.md",
+      "ROADMAP.md",
+      "SECURITY.md",
+      "llms.txt"
+    ]
+  },
+  "verification": {
+    "command": "npm run verify:issue -- .github/drafts/<draft>.md",
+    "advisory_in_ci": true,
+    "blocks_submission_on_failure": true
+  },
+  "references": {
+    "zero_dependency_policy": "README.md",
+    "governance_guide": "docs/guides/AI_GOVERNANCE.md",
+    "issue_templates": [".github/ISSUE_TEMPLATE"]
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-MCP server bridging pdfnative (v1.4.x) to AI clients over stdio. 17 tools.
+MCP server bridging pdfnative (v1.5.x) to AI clients over stdio. 19 tools.
 Quality bar: production-grade OSS (strict TypeScript, strong validation, secure
 file IO, deterministic releases).
 

--- a/.github/drafts/README.md
+++ b/.github/drafts/README.md
@@ -1,0 +1,20 @@
+# Issue Drafts (Human-In-The-Loop staging area)
+
+This directory is the **draft staging area** mandated by the AI-governance
+contract ([.github/ai-governance.json](../ai-governance.json),
+[.github/AGENT_RULES.md](../AGENT_RULES.md)).
+
+AI agents — and the `draft_governance_issue` MCP tool — write proposed GitHub
+issues here as local Markdown files. Nothing in this repository (and nothing in
+the `pdfnative-mcp` server) can submit these drafts automatically.
+
+**Workflow:**
+
+1. An agent (or the `draft_governance_issue` tool) produces `something.md` here
+   plus a compliance report.
+2. Validate it: `npm run verify:issue -- .github/drafts/something.md`
+3. **You** review it, then manually open the issue on GitHub under your own
+   identity. You share responsibility for the content.
+
+Draft files are intentionally git-ignored (except this README) so work-in-progress
+proposals never leak into the repository history.

--- a/.github/drafts/pr-v1.4.0.md
+++ b/.github/drafts/pr-v1.4.0.md
@@ -1,0 +1,88 @@
+# PR: v1.4.0 — AI governance + HITL, markup annotations, pdfnative 1.5
+
+## Summary
+
+A minor, fully backward-compatible release that extends pdfnative-mcp to **19 tools** and brings the pdfnative **AI-governance / Human-In-The-Loop (HITL)** system to the MCP surface. Adds `draft_governance_issue` — a **local, network-free** GitHub-issue drafter that produces a compliant draft `.md` plus a machine-readable compliance report (the agent is a *draftsman, never an autonomous submitter*: a human is the only gate, and the server makes **zero** GitHub writes and no outbound network call). Adds `annotate_pdf` — markup overlays (highlight, note, underline, strikeout, squiggly, square, circle, line, freetext) via pdfnative 1.5's incremental-update annotation writer (a **visual review layer, not a redaction**). Surfaces `/PageLabels` in `inspect_pdf`, adds an explicit `math` script to `add_international_text` (Noto Sans Math, on demand only — **no** global auto-routing), advertises the MCP **`prompts`** capability, and upgrades the engine to [pdfnative v1.5.0](https://github.com/Nizoka/pdfnative). No breaking changes — all v1.3.0 tool calls work unchanged and default responses are byte-identical.
+
+Full notes: [`release-notes/v1.4.0.md`](../../release-notes/v1.4.0.md).
+
+## Scope
+
+| Phase | Subject |
+| --- | --- |
+| 0 | Branch + version bump (package.json `1.4.0`, pdfnative pin `^1.5.0`); `src/version.ts` single source of truth |
+| 1 | AI governance / HITL: `src/governance.ts` (contract + `validateIssueMarkdown`), `GovernanceError` (`src/errors.ts`), `writeSandboxedText` (`src/output.ts`), `draft_governance_issue` tool, MCP prompts (`governance_contract`, `draft_issue_workflow`), `.github/ai-governance.json` + `AGENT_RULES.md` + `drafts/README.md`, `scripts/verify-issue.mjs` (`npm run verify:issue`) |
+| 2 | `annotate_pdf` (markup overlay via pdfnative 1.5 incremental-update writer); `inspect_pdf` `/PageLabels`; `add_international_text` explicit `math` lang via shared `src/fonts.ts` |
+| 3 | Server registration (2 tools → 19, prompts capability + `ListPrompts`/`GetPrompt` handlers, dispatch, `SERVER_VERSION`/`apiVersion` → 1.4.0, decision tree); `index.ts`, `server.json` |
+| 4 | Examples: `annotate-pdf`, `draft-governance-issue`, `math-symbols`, `page-labels-inspect` |
+| 5 | Tests: 4 new suites + extended `server.test.ts` (prompts + 19 tools), `inspect-pdf.test.ts` (pageLabels), `output.test.ts` (.md writer) |
+| 6 | Docs: README, AGENTS.md, AI_GUIDE, API_STABILITY, KNOWLEDGE_BASE, LOCAL_TESTING, ROADMAP, llms.txt, copilot-instructions + new `docs/guides/AI_GOVERNANCE.md` |
+| 7 | Release: `release-notes/v1.4.0.md`, CHANGELOG mirror, this PR draft |
+
+## Closes
+
+- Roadmap: ships the pdfnative **AI-governance / HITL** system as an MCP-native tool + prompts, and `annotate_pdf` on pdfnative v1.5.0's annotation writer.
+- `redact_pdf` stays **deferred by design**: pdfnative 1.5's writer can only *overlay* content, and an overlay-only "redaction" would leave the original bytes intact and create **false security** — it fails this project's honesty bar. Tracked as an upstream true content-removal request (a fitting first use of `draft_governance_issue`). An encrypted-PDF round-trip likewise remains blocked upstream.
+
+## Quality gate
+
+- ✅ `npm run typecheck:all` — 0 errors
+- ✅ `npm run lint` — 0 errors (36 pre-existing non-null-assertion warnings in untouched files)
+- ✅ `npm run test:coverage` — **355 tests** passing; **90.47** stmts / **79.18** branches / **95.81** funcs / **92.51** lines (≥ vitest thresholds 88 / 75 / 85 / 90)
+- ✅ `npm run build` — clean `dist/`
+- ✅ `npm run examples:check` — every `examples/*.json` references a live tool; self-contained examples execute and pass structural assertions
+- ✅ `npm run verify:issue` — CLI validates a compliant draft and mirrors `src/governance.ts` byte-for-byte
+
+## Changes summary
+
+### Added
+- **Tool `draft_governance_issue`** (new, 19th) — assembles a governance-compliant GitHub issue draft plus a structured `compliance` report and returns them; **never submits, no outbound network call**. Inputs: `title`, `issueType` (`bug|feature|security|docs|performance`), `summary`, `reproduction: { command, result }`, `expectedBehavior`, optional `actualBehavior`, `targetRepo` (default `pdfnative-mcp`), `affectedPackages` (default `['pdfnative-mcp']`), `duplicateSearchPerformed` (**must be `true`**), `outputMode` (`'inline'|'file'`) / `outputPath`. Contract breaches (runtime dependency, missing reproduction, `duplicateSearchPerformed:false`) → new `GOVERNANCE_VIOLATION` error.
+- **Tool `annotate_pdf`** (new, 18th) — overlay markup annotations (`text`, `highlight`, `underline`, `strikeout`, `squiggly`, `square`, `circle`, `line`, `freetext`) on an existing PDF via pdfnative 1.5's incremental-update annotation writer. 0-based `page` (bounds-checked), `rect: [x1, y1, x2, y2]`, optional `color`/`contents`. Encrypted sources → `ENCRYPTED_SOURCE`. **Visual overlay only — not a redaction.**
+- **`inspect_pdf`** — optional `pageLabels[]` output field (`{ startPage, style?, prefix?, start? }`), present only when the PDF declares `/PageLabels` (pdfnative 1.5 `getPageLabels()`).
+- **`add_international_text`** — explicit `math` lang code (maps to `noto-sans-math-data.js`, Noto Sans Math), embedded on demand only when requested (e.g. `lang: ['latin', 'math']`) — **no** global auto-routing.
+- **MCP prompts** — the server advertises the `prompts` capability with `governance_contract` (the full contract) and `draft_issue_workflow` (the step-by-step recipe), sourced from `src/governance.ts`.
+- **`src/governance.ts`** — single source of truth for the governance contract: `validateIssueMarkdown()` (zero-dependency + reproduction-block policy), prompt copy, identity/human-gate constants.
+- **`src/version.ts`** — shared `PDFNATIVE_MCP_VERSION` used by the server and the governance tool.
+- **`src/fonts.ts`** — shared font-module directory + loader helpers (deduplicated from `add_international_text`).
+- **`src/errors.ts`** — `GovernanceError` (`GOVERNANCE_VIOLATION`).
+- **`src/output.ts`** — `writeSandboxedText()`; `resolveSandboxedPath()` parameterised on the allowed extension (reuses every existing guard: relative path, no traversal, no NUL, extension enforcement).
+- **Governance contract files** — `.github/ai-governance.json` (machine-readable), `.github/AGENT_RULES.md` (agent-and-human protocol), `.github/drafts/README.md`; `scripts/verify-issue.mjs` CLI (`npm run verify:issue`) mirroring `validateIssueMarkdown()`.
+- **Docs** — new [`docs/guides/AI_GOVERNANCE.md`](../../docs/guides/AI_GOVERNANCE.md) (HITL contract + `draft_governance_issue` workflow).
+- **Examples** — `annotate-pdf.json`, `draft-governance-issue.json`, `math-symbols.json`, `page-labels-inspect.json` (executable, guarded by examples-as-tests).
+- **Tests** — `annotate-pdf.test.ts`, `draft-governance-issue.test.ts`, `governance.test.ts` (asserts the tool, the `verify:issue` CLI, and the repo contract files stay aligned), `fonts.test.ts`; extended `server.test.ts` (prompts + 19 tools), `inspect-pdf.test.ts` (`pageLabels`), `output.test.ts` (`.md` writer).
+
+### Changed
+- **Dependency:** `pdfnative` `^1.4.0` → `^1.5.0` (additive — annotation writer + page-label reader).
+- **MCP `_meta.apiVersion`** bumped `1.3.0` → `1.4.0` on every tool; `SERVER_VERSION`, `server.json` versions, and `package.json` version → `1.4.0`.
+- **Server:** `SERVER_DESCRIPTION` and `SERVER_INSTRUCTIONS` extended to **19 tools** (governance decision branch + corrected math note — explicit lang, **not** global auto-routing); `capabilities` now include `prompts`.
+- **Tool count assertion** in `tests/server.test.ts` — 17 → 19; prompt assertions added.
+- **Docs:** README, `AGENTS.md`, `docs/AI_GUIDE.md`, `docs/API_STABILITY.md`, `docs/KNOWLEDGE_BASE.md`, `docs/guides/LOCAL_TESTING.md`, `ROADMAP.md`, `llms.txt`, and `.github/copilot-instructions.md` refreshed for the 19-tool / pdfnative-1.5 surface.
+
+### Deferred (with rationale)
+- **`redact_pdf`** — deferred **by design**. pdfnative 1.5's annotation writer can only *overlay* content; an overlay-only "redaction" would leave the original bytes intact and create false security. Blocked on an upstream true content-removal API.
+- **Encrypted-PDF round-trip fixtures** — once pdfnative exposes a Standard Security Handler writer.
+
+## Reviewer checklist
+
+- [ ] CHANGELOG.md v1.4.0 entry mirrors `release-notes/v1.4.0.md`
+- [ ] `package.json` version === `server.json` versions === `SERVER_VERSION` === `src/version.ts` === `1.4.0`
+- [ ] Tool count assertion in `tests/server.test.ts` equals 19; list includes `annotate_pdf`, `draft_governance_issue`
+- [ ] Every tool exposes `_meta.apiVersion === '1.4.0'` and a non-empty `_meta.examples` array
+- [ ] **`draft_governance_issue` makes zero network calls** and never writes to GitHub (no `fetch`/http/child_process/GitHub SDK anywhere); a `fetch` spy assertion covers it
+- [ ] `draft_governance_issue` rejects a runtime-dependency proposal, a missing reproduction block, and `duplicateSearchPerformed:false` with `GOVERNANCE_VIOLATION`
+- [ ] `validateIssueMarkdown()` in `src/governance.ts` stays byte-aligned with `scripts/verify-issue.mjs` (asserted by `governance.test.ts`)
+- [ ] `annotate_pdf` maps all 9 types correctly, bounds-checks `page`, and rejects encrypted sources with `ENCRYPTED_SOURCE` — and is documented as overlay, **not** redaction
+- [ ] `inspect_pdf` surfaces `pageLabels[]` when present and omits it when absent
+- [ ] `add_international_text` `math` lang embeds the Noto Sans Math face **only when requested** (no global auto-routing); doc claims match
+- [ ] MCP `prompts` capability advertised; `ListPrompts`/`GetPrompt` return `governance_contract` + `draft_issue_workflow`
+- [ ] `writeSandboxedText` reuses the full sandbox guard set (relative path, no traversal, no NUL, `.md` extension); file-mode drafts stay inside `PDFNATIVE_MCP_OUTPUT_DIR`
+- [ ] `server.json` validates against the MCP registry schema
+- [ ] No `any` added in `src/`; no new CodeQL alerts
+- [ ] Test coverage ≥ vitest thresholds (88 / 75 / 85 / 90)
+
+## Notes for the merger
+
+- No breaking changes; minor bump per [`docs/API_STABILITY.md`](../../docs/API_STABILITY.md) §3 (2 new tools + additive optional output field + new enum value + new prompts capability + a tool-scoped new error code).
+- `redact_pdf` is intentionally **not** shipped — see the deferral rationale above; do not treat its absence as an oversight.
+- Publish is via GitHub Actions Trusted Publishing (OIDC) — no `NPM_TOKEN`.
+- GitHub Release title: `v1.4.0 — AI governance + HITL, markup annotations, pdfnative 1.5`.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ coverage/
 .idea/
 out/
 *.tsbuildinfo
+
+# AI-governance issue drafts are local work-in-progress; never commit them
+# (the staging-area README is force-added and stays tracked).
+.github/drafts/*
+!.github/drafts/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,10 @@ coverage/
 out/
 *.tsbuildinfo
 
-# AI-governance issue drafts are local work-in-progress; never commit them
-# (the staging-area README is force-added and stays tracked).
+# AI-governance issue drafts are local work-in-progress; never commit ad-hoc
+# tool output. Curated release artifacts (pr-*.md / issue-*.md) and the
+# staging-area README stay tracked.
 .github/drafts/*
 !.github/drafts/README.md
+!.github/drafts/pr-*.md
+!.github/drafts/issue-*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ invocations live under [examples/](examples/).
 
 ---
 
-## 1. Tool catalogue (17 tools)
+## 1. Tool catalogue (19 tools)
 
 | # | Tool | Use it for | Read-only |
 |---|------|-----------|:---:|
@@ -34,6 +34,8 @@ invocations live under [examples/](examples/).
 | 15 | `merge_pdfs` | Concatenate 2–50 PDFs into one (page-tree API). | |
 | 16 | `split_pdf` | Split a PDF into one document per page range (multi-output). | |
 | 17 | `extract_pages` | Pull an arbitrary page subset into a single PDF. | ✓¹ |
+| 18 | `annotate_pdf` | Add markup annotations (highlight, sticky note, square/circle, line, freetext). Visual overlay only — does **not** redact underlying content. | |
+| 19 | `draft_governance_issue` | Draft a governance-compliant GitHub issue for **human** review. Produces a local draft + compliance report; **never submits**, no network. | ✓ |
 
 ¹ `extract_pages` only reads the source, but it produces a new PDF, so it is not annotated `readOnlyHint`.
 
@@ -48,6 +50,7 @@ Need a NEW PDF?
  ├─ an image?                              → embed_image
  ├─ an interactive form?                   → add_form
  └─ otherwise                              → generate_basic_pdf
+Annotate an existing PDF (overlay)?       → annotate_pdf
 Combine / carve existing PDFs?
  ├─ join several into one?                 → merge_pdfs
  ├─ split into per-range documents?        → split_pdf
@@ -59,6 +62,7 @@ Need to READ a PDF?
  ├─ PDF/UA conformant?   → validate_pdf
  ├─ embedded files?      → extract_attachments
  └─ plain text?          → extract_text
+Propose a bug/feature to GitHub? → draft_governance_issue (local draft; a human reviews & submits)
 ```
 
 ## 3. Token-frugal responses
@@ -99,6 +103,9 @@ attachments in the caller.
 - **Watermarked report:** `add_table` with `watermark: { text: 'CONFIDENTIAL', opacity: 0.2 }`.
 - **Bookmarked report:** `generate_basic_pdf` with `outline: 'auto'` + `pageLabels` + `viewerPreferences: { pageMode: 'useOutlines' }`.
 - **Assemble / carve:** generate parts → `merge_pdfs`; or `split_pdf` (per range) / `extract_pages` (one subset) → `inspect_pdf` to confirm the page count.
+- **Annotate for review:** `annotate_pdf` with `{ type: 'highlight' }` / `{ type: 'text' }` overlays — a visual review layer, **not** a redaction (underlying bytes remain).
+- **Math / scientific text:** `add_international_text` with `lang: ['latin', 'math']` — `math` is an **explicit** script, embedded only when requested (no global auto-routing).
+- **Propose an upstream change:** `draft_governance_issue` → review the local `.md` draft + compliance report → a **human** submits it to GitHub (the server never does).
 
 ## 6. Error reference
 
@@ -117,6 +124,7 @@ attachments in the caller.
 | `FONT_LOAD_FAILED` | Bundled font module failed to load | Retry; reinstall `pdfnative` if persistent. |
 | `SIGNING_FAILED` · `CMS_PARSE_FAILED` · `EC_KEY_PARSE_FAILED` · `EC_CURVE_UNSUPPORTED` | Signing / key-cert problem | Check DER encodings; ECDSA must be P-256. |
 | `SECURITY_VIOLATION` | Sandbox / path-traversal rejection | Set `PDFNATIVE_MCP_OUTPUT_DIR`; use a relative `.pdf` path. |
+| `GOVERNANCE_VIOLATION` | `draft_governance_issue` draft breaks the AI-governance contract (proposes a runtime dependency, missing reproduction, or `duplicateSearchPerformed:false`) | Remove the dependency proposal, include a reproduction, confirm the duplicate search. |
 
 ## 7. Contributing to this repo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-14
+
+A minor, backward-compatible release that brings the pdfnative AI-governance /
+Human-In-The-Loop (HITL) system to the MCP surface, adds markup annotations and a
+local, network-free GitHub-issue drafter (taking the catalogue to **19 tools**),
+surfaces page labels in `inspect_pdf`, adds an explicit `math` script to
+`add_international_text`, advertises the MCP `prompts` capability, and upgrades to
+[pdfnative v1.5.0](https://github.com/Nizoka/pdfnative). Default tool calls return
+responses identical to v1.3.0 — all new behaviour is opt-in.
+
+### Added
+
+- **Tool `draft_governance_issue`** (19th tool): assembles a governance-compliant GitHub issue draft plus a structured `compliance` report and returns them — never submits, no network call. Rejects contract breaches (runtime dependency, missing reproduction, `duplicateSearchPerformed:false`) with the new `GOVERNANCE_VIOLATION` error.
+- **Tool `annotate_pdf`** (18th tool): overlay markup annotations (`text`, `highlight`, `underline`, `strikeout`, `squiggly`, `square`, `circle`, `line`, `freetext`) on an existing PDF via pdfnative v1.5.0's incremental-update annotation writer. Visual overlay only — not a redaction. Encrypted sources → `ENCRYPTED_SOURCE`.
+- **`inspect_pdf`**: optional `pageLabels[]` output field (`{ startPage, style?, prefix?, start? }`), present only when the PDF declares `/PageLabels`.
+- **`add_international_text`**: explicit `math` lang code (Noto Sans Math), embedded on demand only when requested (no global auto-routing).
+- **MCP prompts:** the server now advertises the `prompts` capability with `governance_contract` and `draft_issue_workflow`.
+- **Governance:** new `src/governance.ts`, `src/version.ts`, `src/fonts.ts`, `GovernanceError` in `src/errors.ts`, `writeSandboxedText()` in `src/output.ts`; contract files `.github/ai-governance.json`, `.github/AGENT_RULES.md`, `.github/drafts/README.md`; `scripts/verify-issue.mjs` CLI (`npm run verify:issue`).
+- **Docs:** new `docs/guides/AI_GOVERNANCE.md` (HITL contract + workflow).
+- **Examples:** `annotate-pdf.json`, `draft-governance-issue.json`, `math-symbols.json`, `page-labels-inspect.json`.
+- **Tests:** `annotate-pdf.test.ts`, `draft-governance-issue.test.ts`, `governance.test.ts`, `fonts.test.ts`; extended `server.test.ts` (prompts + 19 tools), `inspect-pdf.test.ts` (`pageLabels`), `output.test.ts` (`.md` writer).
+
+### Changed
+
+- **Dependency:** `pdfnative` bumped `^1.4.0` → `^1.5.0` (additive; new annotation writer + page-label reader).
+- **MCP `_meta.apiVersion`** bumped `1.3.0` → `1.4.0` on every tool; `SERVER_VERSION`, `server.json` versions, and `package.json` version → `1.4.0`.
+- **Server:** `SERVER_DESCRIPTION` and `SERVER_INSTRUCTIONS` extended to **19 tools** (governance decision branch + corrected math note — explicit lang, not global auto-routing).
+- **Docs:** README, `AGENTS.md`, `docs/AI_GUIDE.md`, `docs/API_STABILITY.md`, `docs/KNOWLEDGE_BASE.md`, `ROADMAP.md`, `llms.txt`, and `.github/copilot-instructions.md` refreshed for the v1.4.0 surface.
+
+### Deferred by design
+
+- **`redact_pdf`** stays deferred. pdfnative v1.5.0's annotation writer can only *overlay* content; an overlay-only "redaction" would leave the original bytes intact and create false security, which fails this project's honesty bar. Tracked as an upstream content-removal feature request. An **encrypted-PDF round-trip** likewise remains blocked on a Standard Security Handler writer.
+
 ## [1.3.0] - 2026-07-07
 
 A minor, backward-compatible release that adds three page-tree tools
@@ -218,7 +251,8 @@ stability via the new per-tool `_meta.apiVersion` field. Built on top of
 - Strict JSON Schema + Zod validation at every tool boundary.
 - Vitest test suite with sandbox security checks.
 
-[Unreleased]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/Nizoka/pdfnative-mcp/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ## ✨ Features
 
-`pdfnative-mcp` exposes **17 production-grade tools** to any MCP host:
+`pdfnative-mcp` exposes **19 production-grade tools** to any MCP host:
 
 | Tool                               | Purpose                                                                                          |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------ |
@@ -37,6 +37,17 @@
 | `merge_pdfs` *(new in v1.3.0)*     | Concatenate 2–50 PDFs into one via pdfnative's page-tree API.                                  |
 | `split_pdf` *(new in v1.3.0)*      | Split one PDF into one document per page range (multi-output).                                  |
 | `extract_pages` *(new in v1.3.0)*  | Pull an arbitrary page subset into a single PDF.                                               |
+| `annotate_pdf` *(new in v1.4.0)*   | Add markup annotations (highlight, note, square/circle, line, freetext) as a visual overlay — **not** a redaction. |
+| `draft_governance_issue` *(new in v1.4.0)* | Draft a governance-compliant GitHub issue locally for **human** review; never submits, no network. |
+
+**New in v1.4.0:**
+
+- 🤝 **AI governance + human-in-the-loop** — `draft_governance_issue` lets an agent draft a fully compliant GitHub issue **locally** (draft `.md` + machine-readable compliance report). The agent is a *draftsman, never an autonomous submitter*: a human is the only gate, and the server makes **zero** GitHub writes and no outbound network calls. Backed by the `governance_contract` and `draft_issue_workflow` MCP prompts.
+- ✏️ **Markup annotations** — `annotate_pdf` overlays highlight, sticky-note, underline, strikeout, squiggly, square, circle, line, and freetext annotations on an existing PDF via incremental update. It is a *visual review layer, not a redaction* — underlying bytes remain.
+- 🔢 **Page labels in `inspect_pdf`** — read-only surfacing of `/PageLabels` ranges (roman, decimal, prefixed).
+- ∑ **Math / scientific script** — `add_international_text` accepts `lang: 'math'` (explicit, like `emoji`) to embed the Noto Sans Math face on demand.
+- 🧩 **MCP prompts** — the server now advertises the `prompts` capability with `governance_contract` and `draft_issue_workflow`.
+- ⬆ **Engine upgrade** — pdfnative **v1.5.0**.
 
 **New in v1.3.0:**
 
@@ -74,7 +85,7 @@
 - 🆕 **AI agent guide:** [`docs/AI_GUIDE.md`](docs/AI_GUIDE.md) — decision tree + common pitfalls. See also the root [`AGENTS.md`](AGENTS.md) operations manual.
 - 🆕 **PDF/A authoring guide:** [`docs/guides/PDFA.md`](docs/guides/PDFA.md).
 - 🛠 **Env-var rename:** `PDFNATIVE_MCP_OUTPUT_DIR` (was `PDFNATIVE_MPC_OUTPUT_DIR`; old name still works with a one-shot deprecation warning).
-- ✅ **Now shipped (v1.3.0):** `merge_pdfs`, `split_pdf`, `extract_pages` — built on pdfnative v1.4.0's page-tree API. `redact_pdf` remains blocked upstream.
+- ✅ **Now shipped:** `merge_pdfs`, `split_pdf`, `extract_pages` (v1.3.0) and `annotate_pdf` (v1.4.0). `redact_pdf` stays **deferred** — pdfnative can only overlay content, and an overlay-only "redaction" would create false security, so it is intentionally not shipped (tracked as an upstream content-removal request).
 
 All tools support two output modes:
 
@@ -221,7 +232,7 @@ Supported formats: `qr`, `code128`, `ean13`, `datamatrix`, `pdf417`.
 }
 ```
 
-Supported `lang` codes: `ar`, `he`, `th`, `ja`, `zh`, `ko`, `el`, `hi`, `bn`, `ta`, `ru`, `ka`, `hy`, `tr`, `vi`, `pl`, `latin`, `emoji`.
+Supported `lang` codes: `ar`, `he`, `th`, `ja`, `zh`, `ko`, `el`, `hi`, `bn`, `ta`, `ru`, `ka`, `hy`, `tr`, `vi`, `pl`, `latin`, `emoji`, `math`.
 
 Multi-script documents — pass an array or comma-separated list:
 
@@ -380,6 +391,39 @@ Returns:
 ```
 
 It verifies catalog `/MarkInfo /Marked true`, `/StructTreeRoot` (+ `/ParentTree`), `/Metadata` (XMP), `/Lang`, and per-page MCID uniqueness. This is a fast developer-time gate — **not** a substitute for a full reference validator (veraPDF), which additionally checks fonts, colour, and rendering.
+
+### `annotate_pdf`
+
+Overlay markup annotations on an existing PDF via incremental update. This is a **visual review layer, not a redaction** — the underlying content is untouched.
+
+```jsonc
+{
+  "pdfBase64": "<base64 PDF>",
+  "annotations": [
+    { "type": "highlight", "page": 0, "rect": [72, 700, 520, 715], "color": [1, 1, 0], "contents": "Check this figure" },
+    { "type": "text", "page": 0, "rect": [540, 700, 560, 720], "contents": "Reviewer note" }
+  ]
+}
+```
+
+Types: `text`, `highlight`, `underline`, `strikeout`, `squiggly`, `square`, `circle`, `line`, `freetext`. Encrypted sources are rejected (`ENCRYPTED_SOURCE`).
+
+### `draft_governance_issue`
+
+Draft a governance-compliant GitHub issue **locally** for a human to review and submit. The server never contacts GitHub and makes no outbound network calls; it returns the draft Markdown plus a machine-readable compliance report.
+
+```jsonc
+{
+  "title": "add_table drops the caption on the second page",
+  "issueType": "bug",
+  "summary": "The table caption is only rendered on page 1 when repeatHeader is true.",
+  "reproduction": { "command": "node examples/run.mjs add-table-caption.json", "result": "Page 2 has no caption row." },
+  "expectedBehavior": "The caption repeats with the header on every page.",
+  "duplicateSearchPerformed": true
+}
+```
+
+A draft that proposes a runtime dependency, omits a reproduction, or sets `duplicateSearchPerformed: false` is rejected with `GOVERNANCE_VIOLATION`. See [`docs/guides/AI_GOVERNANCE.md`](docs/guides/AI_GOVERNANCE.md) for the full human-in-the-loop contract.
 
 ### `verify_pdf`, `add_attachment`, `extract_text`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,11 +85,17 @@ Priorities may shift based on community feedback and sponsorship.
 - [x] **Table cell borders & alignment** — `add_table` gains `cellBorders` and `cellVAlign`.
 - [x] **Constant-time signing** — `sign_pdf` signs RSA and EC-DER keys through a `node:crypto` provider with a transparent pure-JS fallback; signatures stay interoperable.
 
----
+### v1.4.0 — AI governance + HITL, annotations, pdfnative 1.5
 
-## In Progress
+- [x] **pdfnative v1.5.0** — dependency bump `^1.4.0` → `^1.5.0` (additive, no breaking changes).
+- [x] **Tool `annotate_pdf`** — overlay markup annotations (highlight, note, underline, strikeout, squiggly, square, circle, line, freetext) on an existing PDF via incremental update. Visual review layer, **not** a redaction. **18th tool.**
+- [x] **Tool `draft_governance_issue`** — draft a governance-compliant GitHub issue **locally** (draft `.md` + machine-readable compliance report) for human review; never submits, no outbound network; rejects contract breaches with `GOVERNANCE_VIOLATION`. **19th tool.**
+- [x] **AI governance + human-in-the-loop** — the agent is a *draftsman, never an autonomous submitter*; contract files under `.github/` (`ai-governance.json`, `AGENT_RULES.md`), a `verify:issue` CLI gate, and the `docs/guides/AI_GOVERNANCE.md` guide.
+- [x] **MCP prompts** — the server advertises the `prompts` capability with `governance_contract` and `draft_issue_workflow`.
+- [x] **Page labels in `inspect_pdf`** — read-only surfacing of `/PageLabels` ranges.
+- [x] **Math / scientific script** — `add_international_text` accepts the explicit `math` lang (Noto Sans Math), embedded on demand only (no global auto-routing).
 
-_v1.3.0 is the active release. `redact_pdf` and an encrypted-PDF round-trip remain blocked on upstream pdfnative APIs (see Blocked below)._
+_v1.4.0 is the active release. `redact_pdf` stays **deferred** and an encrypted-PDF round-trip remains blocked on upstream pdfnative APIs (see Blocked below)._
 
 ---
 
@@ -98,12 +104,14 @@ _v1.3.0 is the active release. `redact_pdf` and an encrypted-PDF round-trip rema
 ### Blocked upstream
 
 `merge_pdfs`, `split_pdf` and `extract_pages` shipped in v1.3.0 on pdfnative
-v1.4.0's page-tree export API. The remaining items stay **blocked**: pdfnative
-does not yet export a content-redaction API or a Standard Security Handler writer,
-and implementing them on raw primitives would contradict this project's faithful,
-thin-wrapper philosophy. They will ship once pdfnative exports the required APIs.
+v1.4.0's page-tree export API; `annotate_pdf` shipped in v1.4.0 on pdfnative
+v1.5.0's annotation writer. The remaining items stay **blocked/deferred**:
+pdfnative does not yet export a content-*removal* API or a Standard Security
+Handler writer, and implementing them on raw primitives would contradict this
+project's faithful, thin-wrapper philosophy. They will ship once pdfnative
+exports the required APIs.
 
-- [ ] **Tool `redact_pdf`** — overlay-mode (annotation rectangles + replacement text); blocked on pdfnative annotation read/write API. Content-stream redaction tracked separately.
+- [ ] **Tool `redact_pdf`** — **deferred by design.** pdfnative 1.5's annotation writer can only *overlay* content; an overlay-only "redaction" would leave the original bytes intact and create false security, which fails this project's honesty bar. Blocked on an upstream true content-removal API (tracked as a `draft_governance_issue` feature request).
 - [ ] **Encrypted-PDF round-trip fixtures** — once pdfnative exposes a Standard Security Handler writer.
 - [ ] **Per-tool HTTP page-by-page streaming** — once MCP allows partial structuredContent envelopes.
 

--- a/docs/AI_GUIDE.md
+++ b/docs/AI_GUIDE.md
@@ -1,7 +1,7 @@
 # AI Agent Guide — pdfnative-mcp
 
 > **Read this first if you are an AI agent (Copilot, Claude, Cursor, Continue, Zed, Windsurf, Cline, Roo Code, …) about to call pdfnative-mcp.**
-> It tells you which of the 17 tools to pick and how to avoid the common retry loops.
+> It tells you which of the 19 tools to pick and how to avoid the common retry loops.
 
 The server also returns the same decision tree in `serverInfo.instructions`. The full reference lives in [`KNOWLEDGE_BASE.md`](KNOWLEDGE_BASE.md); the stability charter in [`API_STABILITY.md`](API_STABILITY.md). Worked invocations are in [`../examples/`](../examples).
 
@@ -28,6 +28,8 @@ The server also returns the same decision tree in `serverInfo.instructions`. The
 | Join several PDFs into one | `merge_pdfs` |
 | Split one PDF into per-range documents | `split_pdf` |
 | Keep an arbitrary page subset (one PDF) | `extract_pages` |
+| Overlay markup annotations on a PDF (review layer) | `annotate_pdf` |
+| Draft a GitHub issue for a human to submit | `draft_governance_issue` |
 
 ---
 
@@ -87,7 +89,18 @@ The server also returns the same decision tree in `serverInfo.instructions`. The
 
 ### International text
 - `add_international_text` covers **24 scripts** (incl. Telugu, Sinhala, Tibetan, Khmer, Myanmar, Ethiopic) and COLRv1 colour emoji. Pass `lang` as a single code, a comma-separated string, or an array (e.g. `["ar", "emoji"]`) for multi-script runs.
+- For mathematical / scientific symbols, add the **explicit** `math` script, e.g. `lang: ["latin", "math"]`. It embeds the Noto Sans Math face **only when requested** — there is no global auto-routing, so plain `latin` text will not pick up math glyphs on its own.
 - Input is NFC-normalised automatically; you do not need to pre-compose decomposed sequences.
+
+### Annotating an existing PDF (review overlay)
+- `annotate_pdf` overlays markup annotations via an incremental update. Types: `text` (sticky note), `highlight`, `underline`, `strikeout`, `squiggly`, `square`, `circle`, `line`, `freetext`. Each entry needs a 0-based `page`, a `rect: [x1, y1, x2, y2]`, and optional `color` / `contents`.
+- This is a **visual review layer, NOT a redaction** — the underlying page content is untouched, so never use it to hide sensitive data.
+- Encrypted sources are rejected with `ENCRYPTED_SOURCE`; out-of-range `page` indices are rejected by validation.
+
+### Drafting a GitHub issue (human-in-the-loop)
+- `draft_governance_issue` produces a **local** draft `.md` + a machine-readable compliance report. It **never** submits to GitHub and makes **no** outbound network call — you are a draftsman; a human is the only gate that submits.
+- Always set `duplicateSearchPerformed: true` (after actually searching) and include a `reproduction: { command, result }`. Proposing a runtime dependency, omitting the reproduction, or `duplicateSearchPerformed: false` is rejected with `GOVERNANCE_VIOLATION`.
+- Read the `governance_contract` and `draft_issue_workflow` MCP prompts first; the full contract is in [`guides/AI_GOVERNANCE.md`](guides/AI_GOVERNANCE.md).
 
 ### Text extraction
 - `extract_text` returning `extractable: false` is **not an error**. The PDF uses subset fonts without `/ToUnicode` CMaps; the `extractableReason` field explains. The file is not corrupt.
@@ -142,12 +155,20 @@ Defaults are unchanged: omit both and you get the full v1.1.0-identical response
 1. Generate the parts (any authoring tool), then `merge_pdfs` to join them — **or** `split_pdf` (per range) / `extract_pages` (one subset) on an existing PDF.
 2. `inspect_pdf` to confirm the resulting page count.
 
+### Annotate a PDF for review
+1. `annotate_pdf` with `{ type: 'highlight', page, rect, contents }` and/or `{ type: 'text', … }` entries.
+2. *(optional)* `inspect_pdf` to confirm the document still opens and page count is unchanged. Remember: annotations overlay, they do **not** redact.
+
+### Propose an upstream change (human submits)
+1. Search existing issues, then `draft_governance_issue` with a reproduction and `duplicateSearchPerformed: true`.
+2. Review the returned `draftMarkdown` + `complianceReport`; a **human** copies the draft into GitHub and submits it. The server never does.
+
 ---
 
 ## 4. Self-documenting metadata
 
 Every tool ships:
-- `_meta.apiVersion` = `'1.3.0'` — see [`API_STABILITY.md`](API_STABILITY.md).
+- `_meta.apiVersion` = `'1.4.0'` — see [`API_STABILITY.md`](API_STABILITY.md).
 - `_meta.examples`   — at least one worked example per tool. Inspect the `ListTools` response to discover them.
 
 You can rely on these fields when negotiating capabilities before calling a tool.

--- a/docs/API_STABILITY.md
+++ b/docs/API_STABILITY.md
@@ -9,7 +9,7 @@
 
 Every tool emits `_meta.apiVersion` in the `ListTools` response.
 
-Current value: **`1.3.0`** (stable, since pdfnative-mcp 1.3.0).
+Current value: **`1.4.0`** (stable, since pdfnative-mcp 1.4.0).
 
 The tool API version is **independent of the npm release version**.
 Server releases that ship only documentation, refactoring, or non-breaking ergonomic improvements (richer descriptions, additional `_meta.examples`, new optional output fields) **do not** bump `_meta.apiVersion`.
@@ -76,12 +76,23 @@ When a tool, field or error code is scheduled for removal:
 
 ## 5. Per-tool stability matrix
 
-All 17 tools shipped through pdfnative-mcp 1.3.0 are at `_meta.apiVersion = '1.3.0'` and are considered **stable**:
+All 19 tools shipped through pdfnative-mcp 1.4.0 are at `_meta.apiVersion = '1.4.0'` and are considered **stable**:
 
 `generate_basic_pdf`, `add_barcode`, `add_international_text`, `add_table`, `add_form`,
 `embed_image`, `prepare_signature_placeholder`, `sign_pdf`, `verify_pdf`, `validate_pdf`,
 `inspect_pdf`, `add_attachment`, `extract_attachments`, `extract_text`,
-`merge_pdfs`, `split_pdf`, `extract_pages`.
+`merge_pdfs`, `split_pdf`, `extract_pages`, `annotate_pdf`, `draft_governance_issue`.
+
+> **v1.4.0 minor bump rationale:** two **new tools** were added — `annotate_pdf`
+> (markup-overlay annotations on pdfnative v1.5.0's incremental-update annotation writer)
+> and `draft_governance_issue` (local, network-free GitHub-issue drafter with a compliance
+> report). `inspect_pdf` gained an **optional** `pageLabels[]` output field (additive, only
+> present when the PDF declares `/PageLabels`); `add_international_text` gained the explicit
+> `math` lang code (a new accepted enum value that older callers can ignore). A new
+> `GOVERNANCE_VIOLATION` error code is introduced for `draft_governance_issue` only. The
+> server also newly advertises the MCP `prompts` capability (`governance_contract`,
+> `draft_issue_workflow`). All changes are additive per §3; default responses for existing
+> tools are byte-identical to v1.3.0.
 
 > **v1.3.0 minor bump rationale:** three **new tools** (`merge_pdfs`, `split_pdf`,
 > `extract_pages`) were added on pdfnative v1.4.0's page-tree API, and several authoring
@@ -116,7 +127,7 @@ All 17 tools shipped through pdfnative-mcp 1.3.0 are at `_meta.apiVersion = '1.3
 > satisfy the full `outputSchema` (which describes the default `'full'` shape). This is an
 > opt-in token-saving feature; the `outputSchema` contract continues to describe full output.
 
-Page-tree tools `merge_pdfs`, `split_pdf` and `extract_pages` shipped in v1.3.0 on pdfnative v1.4.0's page-tree API. `redact_pdf` and an encrypted-PDF round-trip remain **blocked upstream** — pdfnative does not yet export the required content-redaction / decryption API. They will be added with the same stability guarantees once unblocked.
+Page-tree tools `merge_pdfs`, `split_pdf` and `extract_pages` shipped in v1.3.0 on pdfnative v1.4.0's page-tree API; `annotate_pdf` shipped in v1.4.0 on pdfnative v1.5.0's annotation writer. `redact_pdf` stays **deferred by design** (pdfnative can only overlay, not remove, content — an overlay-only redaction would create false security) and an encrypted-PDF round-trip remains **blocked upstream** (no Standard Security Handler writer). Both will be added with the same stability guarantees once pdfnative exports the required APIs.
 
 ---
 

--- a/docs/KNOWLEDGE_BASE.md
+++ b/docs/KNOWLEDGE_BASE.md
@@ -2,7 +2,7 @@
 
 > Reference for AI assistants (GitHub Copilot, Claude, Cursor, Continue, Zed, Windsurf, Cline, Roo Code)
 > and human contributors. Captures the full context needed to understand, extend, and debug
-> pdfnative-mcp **v1.3.0** without reading every source file.
+> pdfnative-mcp **v1.4.0** without reading every source file.
 
 > If you are an AI agent calling pdfnative-mcp from a chat session, also read
 > [`AI_GUIDE.md`](AI_GUIDE.md) — the short, action-oriented decision tree.
@@ -13,17 +13,18 @@
 
 **What is pdfnative-mcp?**
 An MCP (Model Context Protocol) server that bridges the zero-dependency
-[`pdfnative`](https://github.com/Nizoka/pdfnative) library (v1.4.x) to AI clients
+[`pdfnative`](https://github.com/Nizoka/pdfnative) library (v1.5.x) to AI clients
 (Claude Desktop, ChatGPT, Cursor, Continue, Zed, Windsurf, Cline, Roo Code, …).
-It exposes **17** PDF tools over a stdio transport so AI agents can generate, sign,
-verify, validate, attach, inspect, extract, merge, split and carve PDF files.
+It exposes **19** PDF tools over a stdio transport so AI agents can generate, sign,
+verify, validate, attach, inspect, extract, merge, split, carve, annotate PDF files,
+and draft governance-compliant GitHub issues for human review.
 
 **Philosophy:**
 - `pdfnative` is the only runtime dependency — all PDF logic lives there.
 - The MCP server is a thin, secure dispatch layer: validate inputs with Zod → call pdfnative → emit PDF as base64 or to a sandboxed file.
 - Every tool is fully self-contained (its own file in [src/tools/](../src/tools)).
 - Security at every boundary: Zod validation on all inputs, path traversal prevention on file output, no key-material echo in logs or errors.
-- Every tool ships `_meta.apiVersion = '1.3.0'` and worked-example `_meta.examples` so AI clients can introspect supported behavior — see [`API_STABILITY.md`](API_STABILITY.md).
+- Every tool ships `_meta.apiVersion = '1.4.0'` and worked-example `_meta.examples` so AI clients can introspect supported behavior — see [`API_STABILITY.md`](API_STABILITY.md).
 
 **Runtime:** Node.js ≥ 22 (ESM, strict TypeScript). Transport: stdio.
 
@@ -48,8 +49,11 @@ src/
 ├── normalize.ts      # shared Unicode-normalization schema
 ├── doc-features.ts   # shared schemas/mappers: nested lists, outline, page labels, viewer prefs
 ├── pagetree.ts       # shared page-tree error mapping (merge/split/extract)
+├── fonts.ts          # shared font-module directory + loader helpers
+├── governance.ts     # AI-governance contract: issue validation + prompt copy
+├── version.ts        # single source of truth for PDFNATIVE_MCP_VERSION
 ├── crypto-provider.ts# node:crypto constant-time signature provider
-├── errors.ts         # ToolError + SecurityError
+├── errors.ts         # ToolError + SecurityError + GovernanceError
 └── tools/
     ├── generate-basic-pdf.ts          # generate_basic_pdf
     ├── add-barcode.ts                 # add_barcode
@@ -67,7 +71,9 @@ src/
     ├── extract-text.ts                # extract_text
     ├── merge-pdfs.ts                  # merge_pdfs (page-tree)
     ├── split-pdf.ts                   # split_pdf (page-tree, multi-output)
-    └── extract-pages.ts               # extract_pages (page-tree)
+    ├── extract-pages.ts               # extract_pages (page-tree)
+    ├── annotate-pdf.ts                # annotate_pdf (markup overlay)
+    └── draft-governance-issue.ts      # draft_governance_issue (local HITL draft)
 ```
 
 ### Request Dispatch Flow
@@ -85,6 +91,8 @@ src/cli.ts
 src/server.ts  (createServer)
   ListToolsRequest  → TOOLS registry → JSON schemas + _meta (apiVersion + examples)
   CallToolRequest   → TOOL_INDEX.get(name) → handler(args)
+  ListPromptsRequest→ PROMPTS registry (governance_contract, draft_issue_workflow)
+  GetPromptRequest  → prompt copy from src/governance.ts
     │
     ▼
 src/tools/<tool>.ts
@@ -123,19 +131,19 @@ interface ToolDefinition {
         openWorldHint?: boolean;
     };
     examples?: ReadonlyArray<{ title: string; input: Record<string, unknown> }>;
-    handler: (args: unknown) => Promise<OutputResult | MultiOutputResult | InspectPdfResult | VerifyPdfResult | ExtractTextResult | ValidatePdfResult | ExtractAttachmentsResult>;
+    handler: (args: unknown) => Promise<OutputResult | MultiOutputResult | InspectPdfResult | VerifyPdfResult | ExtractTextResult | ValidatePdfResult | ExtractAttachmentsResult | DraftGovernanceIssueResult>;
 }
 ```
 
 A `TOOL_INDEX: ReadonlyMap<string, ToolDefinition>` is derived from the array for O(1) lookup on `CallToolRequest`.
 
 **`_meta` per tool** — emitted in the `ListTools` response so AI clients can introspect:
-- `_meta.apiVersion` = `'1.3.0'` (see [`API_STABILITY.md`](API_STABILITY.md) for the bump policy)
+- `_meta.apiVersion` = `'1.4.0'` (see [`API_STABILITY.md`](API_STABILITY.md) for the bump policy)
 - `_meta.examples`   = at least one worked example per tool
 
 **Server metadata:**
 - `SERVER_NAME = 'pdfnative-mcp'`
-- `SERVER_VERSION = '1.3.0'`
+- `SERVER_VERSION = '1.4.0'`
 - `serverInfo._meta.mcpName = 'io.github.Nizoka/pdfnative-mcp'` (registry ID in `package.json` `mcpName` / `server.json` `name`; uses the canonical GitHub login casing `Nizoka` so the MCP registry's case-sensitive validation accepts the lowercase npm package `pdfnative-mcp`)
 - `SERVER_INSTRUCTIONS` — high-level decision tree + common-pitfall guide returned to the client in `serverInfo.instructions`
 
@@ -193,7 +201,7 @@ For Factur-X / ZUGFeRD invoices use [`add_attachment`](#add_attachment) instead 
 
 ### `add_international_text`
 
-24 scripts via embedded Noto fonts (Arabic, Hebrew, Thai, Japanese/Chinese/Korean, Devanagari, Bengali, Tamil, Telugu, Sinhala, Tibetan, Khmer, Myanmar, Ethiopic, Cyrillic, Greek, Georgian, Armenian, Turkish, Polish, Vietnamese, Latin, …). BiDi isolates + Arabic harakat + complex-script shaping + COLRv1 colour emoji handled automatically. Input is NFC-normalised by default (`normalize` defaults to `'NFC'`; override with `'NFD'`/`'NFKC'`/`'NFKD'`) for maximal glyph coverage, and embedded newlines auto-split into paragraphs. Lang codes added in v1.1.0: `te` (Telugu), `si` (Sinhala), `bo` (Tibetan), `km` (Khmer), `my` (Myanmar), `am` (Ethiopic); the `emoji` code now maps to `noto-color-emoji-data.js` (COLRv1, monochrome fallback).
+24 scripts via embedded Noto fonts (Arabic, Hebrew, Thai, Japanese/Chinese/Korean, Devanagari, Bengali, Tamil, Telugu, Sinhala, Tibetan, Khmer, Myanmar, Ethiopic, Cyrillic, Greek, Georgian, Armenian, Turkish, Polish, Vietnamese, Latin, …). BiDi isolates + Arabic harakat + complex-script shaping + COLRv1 colour emoji handled automatically. Input is NFC-normalised by default (`normalize` defaults to `'NFC'`; override with `'NFD'`/`'NFKC'`/`'NFKD'`) for maximal glyph coverage, and embedded newlines auto-split into paragraphs. Lang codes added in v1.1.0: `te` (Telugu), `si` (Sinhala), `bo` (Tibetan), `km` (Khmer), `my` (Myanmar), `am` (Ethiopic); the `emoji` code now maps to `noto-color-emoji-data.js` (COLRv1, monochrome fallback). **v1.4.0:** the explicit `math` code maps to `noto-sans-math-data.js` (Noto Sans Math), embedded on demand only when requested (e.g. `lang: ['latin', 'math']`) — there is no global auto-routing.
 
 ### `add_table`
 
@@ -260,6 +268,7 @@ Response shape:
 Structural / security inspection.
 - `version`, `pageCount`, `encryption` (`none|aes-128|aes-256|rc4|unknown`), `pdfA` (`1B|2B|2U|3B|null`)
 - `signatureCount`, `hasSignaturePlaceholder`, `attachments[]`
+- `pageLabels[]` — `/PageLabels` ranges (`{ startPage, style?, prefix?, start? }`) when present, else omitted (v1.4.0)
 - `/Info` dictionary + optional `perPage` sizes
 - Optional `check[]` for CI-style assertions: `'pdfa' | 'signed' | 'encrypted' | 'placeholder' | 'attachments'`. `checksPassed` is the AND of all requested checks.
 
@@ -290,6 +299,20 @@ Splits one PDF into one document per page range (`src/tools/split-pdf.ts`). Inpu
 ### `extract_pages`
 
 Pulls an arbitrary page subset into a single PDF (`src/tools/extract-pages.ts`). Inputs: `pdfBase64`, `pages: number[]` (0-based, max 5000, order preserved), optional `dropAnnotations`, optional `maxOutputSizeBytes`. Returns a single `OutputResult`. Out-of-range indices and encrypted sources are rejected (`PDF_PARSE_FAILED` / `ENCRYPTED_SOURCE`).
+
+### `annotate_pdf`
+
+Overlays markup annotations on an existing PDF via pdfnative's incremental-update annotation writer (`src/tools/annotate-pdf.ts`). Inputs: `pdfBase64`, `annotations: [{ type, page, rect, color?, contents?, … }]`, plus the shared `outputMode`/`outputPath`. Types: `text` (sticky note), `highlight`, `underline`, `strikeout`, `squiggly`, `square`, `circle`, `line`, `freetext` — each mapped to a typed `MarkupAnnotation` union by `toMarkupAnnotation()`. `page` is 0-based and bounds-checked; `rect` is `[x1, y1, x2, y2]` in PDF points. This is a **visual overlay, not a redaction** — the underlying content bytes are untouched. Encrypted sources are rejected with `ENCRYPTED_SOURCE`.
+
+### `draft_governance_issue`
+
+Drafts a governance-compliant GitHub issue **locally** for human review (`src/tools/draft-governance-issue.ts`). It performs **no** network I/O and never submits — the agent is a draftsman, a human is the only gate. Inputs: `title`, `issueType` (`bug|feature|security|docs|performance`), `summary`, `reproduction: { command, result }`, `expectedBehavior`, optional `actualBehavior`, `targetRepo` (default `pdfnative-mcp`), `affectedPackages` (default `['pdfnative-mcp']`), `duplicateSearchPerformed` (**must be `true`**), plus `outputMode` (`'inline'|'file'`) / `outputPath`. Returns `{ draftMarkdown, complianceReport, … }`. Contract enforcement lives in `src/governance.ts` (`validateIssueMarkdown`): proposing a runtime dependency, omitting the reproduction, or `duplicateSearchPerformed: false` throws `GovernanceError('GOVERNANCE_VIOLATION')`. In `file` mode the draft `.md` is written through `writeSandboxedText()` (same sandbox guards as PDF output, `.md` extension). The contract source of truth is under `.github/` (`ai-governance.json`, `AGENT_RULES.md`); the narrative guide is [`guides/AI_GOVERNANCE.md`](guides/AI_GOVERNANCE.md).
+
+### MCP prompts
+
+The server advertises the `prompts` capability (`ListPrompts` / `GetPrompt`). Two prompts, sourced from `src/governance.ts`:
+- `governance_contract` — the full AI-governance contract the agent must honour.
+- `draft_issue_workflow` — the step-by-step recipe for using `draft_governance_issue`.
 
 ---
 
@@ -335,6 +358,10 @@ interface MultiOutputResult {
 
 Each part is capped at 50 MiB and the aggregate at 200 MiB (`MAX_MULTI_OUTPUT_BYTES`); `emitPdfMulti()` writes indexed sandbox files or returns one base64 part per range.
 
+### Text output (`writeSandboxedText`)
+
+`draft_governance_issue` in `file` mode writes its `.md` draft through `writeSandboxedText(text, outputPath, '.md')`, which reuses `resolveSandboxedPath()` (now parameterised on the allowed extension) so the draft is subject to the exact same sandbox guards as PDF output (relative path, no traversal, no NUL, enforced extension).
+
 ---
 
 ## 6. Caching ([src/cache.ts](../src/cache.ts))
@@ -352,6 +379,9 @@ class ToolError extends Error {
 }
 class SecurityError extends ToolError {
     code = 'SECURITY_VIOLATION';
+}
+class GovernanceError extends ToolError {
+    code = 'GOVERNANCE_VIOLATION';   // draft_governance_issue contract breach
 }
 ```
 

--- a/docs/guides/AI_GOVERNANCE.md
+++ b/docs/guides/AI_GOVERNANCE.md
@@ -1,0 +1,150 @@
+# AI Governance & Human-In-The-Loop (HITL)
+
+> How an AI agent may propose bugs and improvements for the pdfnative project
+> **without ever writing to GitHub**. The agent is a **draftsman**; a human is the
+> only gate that submits.
+
+This guide is the narrative companion to the machine-readable contract in
+[`.github/ai-governance.json`](../../.github/ai-governance.json) and the
+agent-and-human protocol in [`.github/AGENT_RULES.md`](../../.github/AGENT_RULES.md).
+It is surfaced to agents through the `draft_governance_issue` tool and the
+`governance_contract` / `draft_issue_workflow` MCP prompts.
+
+---
+
+## 1. The one rule
+
+**The pdfnative-mcp server contains no code path that can write to GitHub or make
+any outbound network call.** It cannot open an issue, comment, PR, or release. It
+produces a **local draft** plus a **compliance report** and stops. A human must
+review the draft and submit it themselves, under their own GitHub identity.
+
+This is a guarantee **by construction**, not merely by policy: there is no HTTP
+client, no `fetch`, and no GitHub SDK anywhere in the server.
+
+---
+
+## 2. Why this exists
+
+The pdfnative project has two hard, non-negotiable properties that an
+autonomously-filing agent would routinely break:
+
+- **Zero runtime dependencies.** A well-meaning agent that "fixes" a bug by
+  proposing `npm install some-lib` violates the core philosophy.
+- **Signal over noise.** Auto-filed, unreproduced, or duplicate issues erode the
+  tracker for human maintainers.
+
+Keeping a human in the loop preserves both, while still letting agents do the
+valuable up-front work: reproduce, categorise, and draft a high-quality issue.
+
+---
+
+## 3. The contract (six non-negotiable rules)
+
+1. **Zero runtime dependencies** — never propose adding an external runtime npm
+   package. (Enforced: a draft that suggests `npm install <pkg>`, a `yarn/pnpm/bun add`,
+   or edits `"dependencies"` is rejected with `GOVERNANCE_VIOLATION`.)
+2. **No duplicates** — search **open AND closed** issues/PRs before drafting.
+   (`duplicateSearchPerformed` must be `true`.)
+3. **Local reproduction** — run a minimal repro (an MCP tool call or a Node/TS
+   snippet) first and capture the exact command + result. (Enforced: the draft must
+   contain a fenced ```` ``` ```` reproduction block.)
+4. **Byte-identity / schema awareness** — keep default output byte-identical and
+   keep the JSON Schema aligned with the Zod schema.
+5. **Human-in-the-loop gate** — produce a **local** draft only; a human reviews and
+   submits.
+6. **Identity integrity** — remind the user that the issue publishes under **their**
+   GitHub identity and that they share responsibility for its content.
+
+---
+
+## 4. The workflow
+
+```
+1. Detect a bug or improvement while working locally.
+2. Reproduce it — run a minimal MCP tool call or Node/TS snippet; capture the exact command + result.
+3. Confirm zero new runtime dependency is required (a hard blocker otherwise).
+4. Search existing open AND closed issues/PRs for duplicates.
+5. Call draft_governance_issue with the title, summary, issueType, reproduction, expected vs actual, and affected packages.
+6. Present the returned draft markdown AND the compliance report to the user.
+7. STOP. The user reviews, then manually opens the issue on GitHub under their own identity.
+```
+
+The `draft_issue_workflow` MCP prompt returns exactly these steps.
+
+---
+
+## 5. Using the `draft_governance_issue` tool
+
+Minimal call:
+
+```jsonc
+{
+  "title": "add_table drops the caption on the second page",
+  "issueType": "bug",
+  "summary": "When repeatHeader is true, the caption row only renders on page 1; subsequent pages repeat the header without the caption.",
+  "reproduction": {
+    "command": "node examples/run.mjs add-table-caption.json",
+    "result": "Page 2 shows the header row but no caption row."
+  },
+  "expectedBehavior": "The caption repeats together with the header on every page.",
+  "duplicateSearchPerformed": true
+}
+```
+
+Optional inputs:
+
+| Field | Default | Notes |
+|-------|---------|-------|
+| `targetRepo` | `pdfnative-mcp` | Documentation label only — the server never contacts it. Usually `pdfnative-mcp` or `pdfnative`. |
+| `actualBehavior` | reproduction result | What actually happened. |
+| `affectedPackages` | `['pdfnative-mcp']` | Impacted packages. |
+| `outputMode` | `inline` | `file` also writes the draft `.md` into `PDFNATIVE_MCP_OUTPUT_DIR`. |
+| `outputPath` | — | Relative `.md` path inside the sandbox (only when `outputMode: 'file'`). |
+
+### What you get back
+
+- `draftMarkdown` — the full issue, ready for a human to review and paste into GitHub.
+- `compliance` — a structured report the agent MUST present alongside the draft:
+  `zeroDependencyConfirmed`, `reproductionCommand`, `reproductionResult`,
+  `duplicateSearchPerformed`, `affectedPackages`, `identityReminderShown`,
+  `humanGate`, and the captured `environment` (`node`, `os`, `pdfnativeMcp`).
+- `warnings` — advisory notes (e.g. a recommended field appears to be missing).
+
+### When it refuses (`GOVERNANCE_VIOLATION`)
+
+The draft is rejected before you can submit it if it:
+
+- proposes an external runtime dependency,
+- omits a reproduction code block, or
+- sets `duplicateSearchPerformed: false`.
+
+Fix the draft and call again. This keeps the human from ever submitting a
+contract-breaking issue.
+
+---
+
+## 6. Verifying a draft on disk
+
+When `outputMode: 'file'` is used, the draft `.md` lands in the sandbox. A human
+(or CI) can re-check it with the same policy the tool applied:
+
+```bash
+npm run verify:issue -- .github/drafts/<draft>.md
+```
+
+`scripts/verify-issue.mjs` mirrors `validateIssueMarkdown()` in
+[`src/governance.ts`](../../src/governance.ts) byte-for-byte, so the CLI and the
+tool never disagree. `tests/governance.test.ts` asserts that alignment.
+
+---
+
+## 7. What the server will never do
+
+- Open, edit, comment on, or close a GitHub issue or PR.
+- Trigger a release.
+- Make any outbound network request or emit telemetry.
+- Persist your draft anywhere except the opt-in `PDFNATIVE_MCP_OUTPUT_DIR` sandbox
+  when you explicitly ask for `outputMode: 'file'`.
+
+The agent drafts. The human decides. That is the whole contract.

--- a/docs/guides/LOCAL_TESTING.md
+++ b/docs/guides/LOCAL_TESTING.md
@@ -143,7 +143,7 @@ The cleanest way to drive it interactively is the official
 npx @modelcontextprotocol/inspector node dist/cli.js
 ```
 
-From the Inspector you can list the 17 tools, inspect each schema and the
+From the Inspector you can list the 19 tools, inspect each schema and the
 `_meta.examples`, and issue `tools/call` requests — a fast way to confirm a new or
 changed tool behaves before writing assertions.
 

--- a/examples/annotate-pdf.json
+++ b/examples/annotate-pdf.json
@@ -1,0 +1,26 @@
+{
+  "description": "Add markup annotations to an existing PDF (pdfnative v1.5 annotation writer via annotate_pdf). Non-destructive incremental update: the original content is preserved byte-for-byte and each annotation is appended to the target page's /Annots. Types shown: highlight (text-markup), a sticky note (/Text) and a red square. NOTE: annotations are VISUAL OVERLAYS — they do NOT remove or redact the underlying content (the covered text stays extractable). Typical flow: generate the PDF, then annotate it. Replace <base64-of-a-pdf> with real bytes.",
+  "steps": [
+    {
+      "tool": "generate_basic_pdf",
+      "arguments": {
+        "title": "Draft for review",
+        "blocks": [
+          { "type": "heading", "text": "Quarterly figures", "level": 1 },
+          { "type": "paragraph", "text": "Revenue grew 12% quarter over quarter." }
+        ]
+      }
+    },
+    {
+      "tool": "annotate_pdf",
+      "arguments": {
+        "pdfBase64": "<base64-of-the-generated-pdf>",
+        "annotations": [
+          { "page": 0, "type": "highlight", "rect": [72, 700, 320, 720], "color": "#ffe600", "contents": "Confirm this number" },
+          { "page": 0, "type": "text", "rect": [520, 700, 540, 720], "contents": "Reviewer note: verify source", "icon": "Note", "open": false },
+          { "page": 0, "type": "square", "rect": [70, 690, 322, 724], "color": "#d00000", "borderWidth": 2 }
+        ]
+      }
+    }
+  ]
+}

--- a/examples/draft-governance-issue.json
+++ b/examples/draft-governance-issue.json
@@ -1,0 +1,18 @@
+{
+  "description": "Draft a governance-compliant GitHub issue for HUMAN review — never submitted (pdfnative-mcp v1.4 AI-governance / Human-In-The-Loop). draft_governance_issue assembles a local Markdown draft plus a structured compliance report and validates it against the zero-dependency + reproduction policy. The server makes NO outbound network call and has NO GitHub write path: present the returned draft and compliance report to the user, then STOP — they review and submit it manually under their own GitHub identity. Fully self-contained (no PDF needed).",
+  "tool": "draft_governance_issue",
+  "arguments": {
+    "title": "add_table clips descenders on wrapped cells at default padding",
+    "summary": "When a table cell wraps onto multiple lines, the descenders of g/j/p/q/y in the last line are clipped at the default cellPadding. Increasing cellPadding works around it but should not be required.",
+    "issueType": "bug",
+    "targetRepo": "pdfnative",
+    "reproduction": {
+      "command": "add_table with headers ['Note'] and a wrapped cell containing 'paragraphy typography'",
+      "result": "The descenders of g/p/y in the wrapped line are visibly clipped in the rendered PDF."
+    },
+    "expectedBehavior": "Descenders render fully within the cell at the default padding.",
+    "actualBehavior": "The bottom ~1pt of g/j/p/q/y is clipped on wrapped lines.",
+    "affectedPackages": ["pdfnative", "pdfnative-mcp"],
+    "duplicateSearchPerformed": true
+  }
+}

--- a/examples/math-symbols.json
+++ b/examples/math-symbols.json
@@ -1,0 +1,13 @@
+{
+  "description": "Render mathematical / technical symbols (pdfnative v1.5 math font, Noto Sans Math OFL-1.1). Pass 'math' alongside a base script (here lang: ['latin','math']) so add_international_text routes math codepoints (∀ ∃ √ ∑ ∫ ∞ ± ÷ ×) to the bundled math font while Latin prose uses Noto Sans. Fully self-contained.",
+  "tool": "add_international_text",
+  "arguments": {
+    "title": "Math notation demo",
+    "lang": ["latin", "math"],
+    "paragraphs": [
+      "For all x ∈ ℝ, we have √(x²) = |x| and ∑ i = n(n+1)/2.",
+      "The definite integral ∫ f dx converges, with error ± ε and ratio a ÷ b × c.",
+      "As n → ∞, the sequence approaches its supremum."
+    ]
+  }
+}

--- a/examples/page-labels-inspect.json
+++ b/examples/page-labels-inspect.json
@@ -1,0 +1,28 @@
+{
+  "description": "Round-trip logical page numbering: author page labels then read them back (pdfnative v1.5 getPageLabels surfaced by inspect_pdf). generate_basic_pdf writes a /PageLabels number tree (roman front-matter then decimal body); inspect_pdf now returns those ranges as a 'pageLabels' array so an agent can confirm the numbering it just authored. Replace <base64-of-the-generated-pdf> with the bytes from step 1.",
+  "steps": [
+    {
+      "tool": "generate_basic_pdf",
+      "arguments": {
+        "title": "Report with logical page numbers",
+        "pageLabels": [
+          { "startPage": 0, "style": "roman" },
+          { "startPage": 2, "style": "decimal", "start": 1 }
+        ],
+        "blocks": [
+          { "type": "heading", "text": "Preface", "level": 1 },
+          { "type": "pageBreak" },
+          { "type": "paragraph", "text": "Front matter, numbered i, ii." },
+          { "type": "pageBreak" },
+          { "type": "heading", "text": "1. Body", "level": 1 }
+        ]
+      }
+    },
+    {
+      "tool": "inspect_pdf",
+      "arguments": {
+        "pdfBase64": "<base64-of-the-generated-pdf>"
+      }
+    }
+  ]
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # pdfnative-mcp
 
-> Production-grade Model Context Protocol (MCP) server for **PDF generation, PDF/A archival, PDF/UA structural validation, PAdES sign & verify (constant-time node:crypto), page-tree operations (merge / split / extract), Factur-X invoices, and PDF introspection**. Zero runtime dependencies beyond pdfnative + the MCP SDK.
+> Production-grade Model Context Protocol (MCP) server for **PDF generation, PDF/A archival, PDF/UA structural validation, PAdES sign & verify (constant-time node:crypto), page-tree operations (merge / split / extract), markup annotations, Factur-X invoices, PDF introspection, and an AI-governance human-in-the-loop issue drafter**. Zero runtime dependencies beyond pdfnative + the MCP SDK.
 
 - Repository: https://github.com/Nizoka/pdfnative-mcp
 - npm: https://www.npmjs.com/package/pdfnative-mcp
@@ -9,6 +9,7 @@
 - API stability charter: https://github.com/Nizoka/pdfnative-mcp/blob/main/docs/API_STABILITY.md
 - Knowledge base (full reference): https://github.com/Nizoka/pdfnative-mcp/blob/main/docs/KNOWLEDGE_BASE.md
 - PDF/A authoring guide: https://github.com/Nizoka/pdfnative-mcp/blob/main/docs/guides/PDFA.md
+- AI governance & HITL guide: https://github.com/Nizoka/pdfnative-mcp/blob/main/docs/guides/AI_GOVERNANCE.md
 
 ## What this server is for
 
@@ -22,17 +23,19 @@ When an AI agent (Claude, Cursor, ChatGPT, Continue, Zed, Windsurf, Cline, Roo C
 - digitally sign a PDF (PAdES CMS, RSA-SHA256 or ECDSA-SHA256/P-256) and **verify the signature in a second call**,
 - attach machine-readable XML to a PDF/A-3 document (Factur-X / ZUGFeRD invoices), and **extract those attachments back out**,
 - extract plain text from a PDF,
-- inspect PDF metadata (version, page count, encryption, PDF/A claim, signatures, attachments),
+- inspect PDF metadata (version, page count, encryption, PDF/A claim, signatures, attachments, page labels),
+- overlay markup annotations (highlight, note, shapes) on an existing PDF,
+- draft a governance-compliant GitHub issue **locally** for a human to review and submit,
 
 …this server is the recommended bridge.
 
-## Tools (17)
+## Tools (19)
 
 | Tool | Purpose |
 | --- | --- |
 | generate_basic_pdf | Multi-page documents from structured blocks (headings, paragraphs, nested lists). Embedded newlines auto-split into paragraphs. Optional pdfA, watermark, normalize, outline (bookmarks), pageLabels, viewerPreferences. |
 | add_barcode | QR / Code 128 / EAN-13 / Data Matrix / PDF417. |
-| add_international_text | 24 scripts via embedded Noto fonts; BiDi, shaping, COLRv1 colour emoji; opt-in normalize (default NFC); optional viewerPreferences. |
+| add_international_text | 24 scripts via embedded Noto fonts; BiDi, shaping, COLRv1 colour emoji; explicit `math` script on demand; opt-in normalize (default NFC); optional viewerPreferences. |
 | add_table | Tabular reports. Smart fields: wrap, repeatHeader, zebra, caption, minRowHeight, cellPadding, cellBorders, cellVAlign. Optional watermark, viewerPreferences. |
 | add_form | Interactive AcroForm (text, checkbox, radio, dropdown). |
 | embed_image | Embed a JPEG / PNG image with optional caption. |
@@ -43,12 +46,14 @@ When an AI agent (Claude, Cursor, ChatGPT, Continue, Zed, Windsurf, Cline, Roo C
 | add_attachment | Generate a PDF/A-3 document with embedded files (Factur-X / ZUGFeRD). |
 | extract_attachments | Read-only extraction of embedded files (Factur-X / ZUGFeRD round-trip), byte-for-byte payloads. |
 | extract_text | Best-effort plain-text extraction from a non-encrypted PDF. |
-| inspect_pdf | Read-only inspection (version, pages, encryption, PDF/A claim, signatures, attachments). |
+| inspect_pdf | Read-only inspection (version, pages, encryption, PDF/A claim, signatures, attachments, page labels). |
 | merge_pdfs | Concatenate 2–50 PDFs into one (page-tree API). Drops signatures/AcroForm; rejects encrypted sources. |
 | split_pdf | Split a PDF into one document per page range (multi-output). |
 | extract_pages | Pull an arbitrary page subset into a single PDF. |
+| annotate_pdf | Overlay markup annotations (highlight, note, underline, strikeout, squiggly, square, circle, line, freetext) on an existing PDF. Visual layer only — not a redaction. |
+| draft_governance_issue | Draft a governance-compliant GitHub issue **locally** (draft + compliance report). Never submits, no network; a human is the only gate. |
 
-Every tool exposes `_meta.apiVersion` (currently `1.3.0`) and `_meta.examples` for AI-agent discovery.
+Every tool exposes `_meta.apiVersion` (currently `1.4.0`) and `_meta.examples` for AI-agent discovery.
 
 ## Page-tree operations (v1.3.0, pdfnative v1.4)
 
@@ -75,6 +80,23 @@ The read-only tools (`inspect_pdf`, `verify_pdf`, `validate_pdf`, `extract_text`
 - `fields: ['a', 'b.c']` — dot-path projection of the structured result; composes after `verbosity`. Unknown paths are omitted leniently.
 
 Defaults are unchanged (`verbosity: 'full'`, no `fields`). Generated PDFs are returned **once** as an embedded `resource` content block (base64 `data:` URI) and are no longer duplicated into `structuredContent`.
+
+## AI governance + human-in-the-loop (v1.4.0, pdfnative v1.5)
+
+`draft_governance_issue` lets an agent propose an upstream bug/feature **without ever touching GitHub**. The agent is a *draftsman, never an autonomous submitter*:
+
+- Input: `title`, `issueType` (`bug`/`feature`/`security`/`docs`/`performance`), `summary`, `reproduction` (`{ command, result }`), `expectedBehavior`, optional `actualBehavior`, `affectedPackages`, and `duplicateSearchPerformed` (**must be `true`**).
+- Output: a ready-to-paste `draftMarkdown` issue plus a machine-readable `complianceReport`; nothing is submitted and no outbound network call is made.
+- A draft that proposes a runtime dependency, omits a reproduction, or sets `duplicateSearchPerformed: false` is rejected with `GOVERNANCE_VIOLATION`.
+- The server advertises the `prompts` capability with two prompts: `governance_contract` (the full contract) and `draft_issue_workflow` (the step-by-step recipe). A human is the only gate that submits the issue. See `docs/guides/AI_GOVERNANCE.md`.
+
+## Markup annotations (v1.4.0)
+
+`annotate_pdf` overlays markup annotations on an existing PDF through an incremental update. Types: `text` (sticky note), `highlight`, `underline`, `strikeout`, `squiggly`, `square`, `circle`, `line`, `freetext`. Each annotation takes a 0-based `page`, a `rect: [x1, y1, x2, y2]`, optional `color`, and `contents`. This is a **visual review layer, not a redaction** — the underlying page content is untouched. Encrypted sources are rejected with `ENCRYPTED_SOURCE`.
+
+## Math / scientific script (v1.4.0)
+
+`add_international_text` accepts `lang: 'math'` (explicit, like `emoji`) to embed the Noto Sans Math face on demand. There is **no** global auto-routing — math glyphs are only embedded when the caller requests the `math` script, e.g. `lang: ['latin', 'math']`.
 
 ## PDF/A authoring survival directives
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "pdfnative-mcp",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "pdfnative-mcp",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.29.0",
-                "pdfnative": "^1.4.0",
+                "pdfnative": "^1.5.0",
                 "zod": "^4.0.0"
             },
             "bin": {
@@ -3115,9 +3115,9 @@
             "license": "MIT"
         },
         "node_modules/pdfnative": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/pdfnative/-/pdfnative-1.4.0.tgz",
-            "integrity": "sha512-AckW7BeWr+nRoazFVB5/EoOXs1UOermEqsxL6fUnRV5jvD5+I953PvkDJZtiIWtTk41NsRQLVUFFAr1FKtW8bg==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/pdfnative/-/pdfnative-1.5.0.tgz",
+            "integrity": "sha512-dl9UYcbErGqtKivaW6lPTqA4t9wqv1xEbQZYq3p1ykbUGS9yKo5PyBCHj1H2skcq54aNON/G/tPAvqyRYz6ZwA==",
             "license": "MIT",
             "bin": {
                 "pdfnative-build-emoji-font": "dist/tools/build-emoji-font.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "pdfnative-mcp",
-    "version": "1.3.0",
-    "description": "Model Context Protocol (MCP) server bridging the zero-dependency pdfnative v1.4 library — generate PDFs (PDF/A-1b/2b/2u/3b) with bookmarks/outline, page labels & viewer preferences, merge / split / extract pages, validate PDF/UA structure, embed barcodes & QR codes, sign (constant-time node:crypto) and **verify** PAdES documents (RSA / ECDSA P-256 CMS), render 24 scripts including colour emoji, build smart tables (cell borders + vertical alignment) and AcroForms, embed images, embed files (Factur-X / ZUGFeRD PDF/A-3), extract text, and inspect existing PDFs — from any MCP-compatible AI client (Claude, Cursor, ChatGPT, Continue, Zed, Windsurf, Cline, Roo Code, …).",
+    "version": "1.4.0",
+    "description": "Model Context Protocol (MCP) server bridging the zero-dependency pdfnative v1.5 library — generate PDFs (PDF/A-1b/2b/2u/3b) with bookmarks/outline, page labels & viewer preferences, add markup annotations, merge / split / extract pages, validate PDF/UA structure, embed barcodes & QR codes, sign (constant-time node:crypto) and **verify** PAdES documents (RSA / ECDSA P-256 CMS), render 24 scripts including colour emoji and math symbols, build smart tables (cell borders + vertical alignment) and AcroForms, embed images, embed files (Factur-X / ZUGFeRD PDF/A-3), extract text, inspect existing PDFs, and draft human-in-the-loop GitHub issues under an AI-governance contract — from any MCP-compatible AI client (Claude, Cursor, ChatGPT, Continue, Zed, Windsurf, Cline, Roo Code, …).",
     "mcpName": "io.github.Nizoka/pdfnative-mcp",
     "keywords": [
         "mcp",
@@ -148,12 +148,13 @@
         "test:watch": "vitest",
         "test:coverage": "vitest run --coverage",
         "examples:check": "vitest run tests/examples.test.ts",
+        "verify:issue": "node scripts/verify-issue.mjs",
         "prepare": "npm run build",
         "prepublishOnly": "npm run clean && npm run lint && npm run typecheck && npm run test && npm run build"
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "pdfnative": "^1.4.0",
+        "pdfnative": "^1.5.0",
         "zod": "^4.0.0"
     },
     "devDependencies": {

--- a/release-notes/v1.4.0.md
+++ b/release-notes/v1.4.0.md
@@ -1,0 +1,144 @@
+# pdfnative-mcp v1.4.0 — AI governance + HITL, markup annotations, pdfnative 1.5
+
+<!-- GitHub Release title: v1.4.0 - AI governance + HITL, markup annotations, pdfnative 1.5 -->
+
+_Released 2026-07-14_
+
+A minor, backward-compatible release that brings the pdfnative **AI-governance /
+Human-In-The-Loop (HITL)** system to the MCP surface, adds **markup annotations**
+and a **local, network-free GitHub-issue drafter** (taking the catalogue to
+**19 tools**), surfaces **page labels** in `inspect_pdf`, adds an explicit **math**
+script to `add_international_text`, advertises the MCP **`prompts`** capability, and
+upgrades the engine to [pdfnative v1.5.0](https://github.com/Nizoka/pdfnative). No
+breaking changes: every v1.3.0 call works unchanged and default responses are
+byte-identical — all new behaviour is opt-in.
+
+## Highlights
+
+- 🤝 **AI governance + Human-In-The-Loop** — new `draft_governance_issue` tool lets an
+  agent draft a fully compliant GitHub issue **locally** (draft `.md` + a
+  machine-readable compliance report). The agent is a **draftsman, never an autonomous
+  submitter**: a human is the only gate, and — by construction, not just policy — the
+  server makes **zero** GitHub writes and **no** outbound network call.
+- ✏️ **Markup annotations** — new `annotate_pdf` tool overlays highlight, sticky-note,
+  underline, strikeout, squiggly, square, circle, line, and freetext annotations on an
+  existing PDF via incremental update. A **visual review layer, not a redaction** — the
+  underlying bytes remain.
+- 🧩 **MCP prompts** — the server now advertises the `prompts` capability with
+  `governance_contract` (the full contract) and `draft_issue_workflow` (the step-by-step
+  recipe).
+- 🔢 **Page labels in `inspect_pdf`** — read-only surfacing of `/PageLabels` ranges.
+- ∑ **Math / scientific script** — `add_international_text` accepts the explicit
+  `math` lang (Noto Sans Math), embedded on demand only (e.g. `lang: ['latin', 'math']`);
+  there is **no** global auto-routing.
+- ⬆ **Engine upgrade** — pdfnative `^1.4.0` → `^1.5.0` (additive, no breaking changes).
+
+## Added
+
+- **feat(tools):** **`draft_governance_issue`** (19th tool) — assembles a
+  governance-compliant issue draft plus a structured `compliance` report and returns
+  them; it never submits and makes no network call. Inputs: `title`, `issueType`
+  (`bug|feature|security|docs|performance`), `summary`, `reproduction: { command, result }`,
+  `expectedBehavior`, optional `actualBehavior`, `targetRepo` (default `pdfnative-mcp`),
+  `affectedPackages` (default `['pdfnative-mcp']`), `duplicateSearchPerformed` (**must be
+  `true`**), and `outputMode` (`'inline'|'file'`) / `outputPath`. A draft that proposes a
+  runtime dependency, omits a reproduction, or sets `duplicateSearchPerformed: false` is
+  rejected with the new `GOVERNANCE_VIOLATION` error.
+- **feat(tools):** **`annotate_pdf`** (18th tool) — overlay markup annotations on an
+  existing PDF via pdfnative v1.5.0's incremental-update annotation writer. Types: `text`,
+  `highlight`, `underline`, `strikeout`, `squiggly`, `square`, `circle`, `line`, `freetext`;
+  each takes a 0-based `page`, a `rect: [x1, y1, x2, y2]`, and optional `color`/`contents`.
+  Encrypted sources → `ENCRYPTED_SOURCE`; out-of-range `page` → validation error.
+- **feat(tools):** `inspect_pdf` gains an optional `pageLabels[]` output field
+  (`{ startPage, style?, prefix?, start? }`), present only when the PDF declares
+  `/PageLabels`.
+- **feat(tools):** `add_international_text` gains the explicit `math` lang code (maps to
+  `noto-sans-math-data.js`), embedded on demand only when requested.
+- **feat(server):** the MCP `prompts` capability is now advertised with two prompts —
+  `governance_contract` and `draft_issue_workflow` — sourced from `src/governance.ts`.
+- **feat(governance):** new `src/governance.ts` (single source of truth: issue validation
+  + prompt copy), `src/version.ts` (shared `PDFNATIVE_MCP_VERSION`), `src/fonts.ts` (shared
+  font-module loader), and `GovernanceError` in `src/errors.ts`.
+- **feat(output):** new `writeSandboxedText()` in `src/output.ts` (reuses all sandbox
+  guards with a parameterised extension) for writing `.md` drafts in `file` mode.
+- **governance contract:** `.github/ai-governance.json` (machine-readable),
+  `.github/AGENT_RULES.md` (agent-and-human protocol), `.github/drafts/README.md`, and a
+  `scripts/verify-issue.mjs` CLI (`npm run verify:issue`) that mirrors
+  `validateIssueMarkdown()` byte-for-byte.
+- **docs:** new [`docs/guides/AI_GOVERNANCE.md`](../docs/guides/AI_GOVERNANCE.md) — the
+  narrative HITL contract + `draft_governance_issue` workflow.
+- **examples:** `annotate-pdf.json`, `draft-governance-issue.json`, `math-symbols.json`,
+  `page-labels-inspect.json` (executable, guarded by examples-as-tests).
+- **test:** new suites `annotate-pdf.test.ts`, `draft-governance-issue.test.ts`,
+  `governance.test.ts` (asserts the tool, the `verify:issue` CLI, and the repo contract
+  files all agree), and `fonts.test.ts`; extended `server.test.ts` (prompts + 19 tools),
+  `inspect-pdf.test.ts` (`pageLabels`), and `output.test.ts` (`.md` writer).
+
+## Changed
+
+- **chore(deps):** upgraded `pdfnative` `^1.4.0` → `^1.5.0` (additive; new annotation
+  writer + page-label reader).
+- **chore(release):** `SERVER_VERSION`, `server.json` versions, and `_meta.apiVersion`
+  bumped `1.3.0` → `1.4.0` on every tool; `package.json` version → `1.4.0`.
+- **change(server):** `SERVER_DESCRIPTION` and `SERVER_INSTRUCTIONS` extended to **19
+  tools** with the governance decision branch and the corrected math note (explicit lang,
+  **not** global auto-routing).
+- **docs:** README, `AGENTS.md`, `docs/AI_GUIDE.md`, `docs/API_STABILITY.md`,
+  `docs/KNOWLEDGE_BASE.md`, `ROADMAP.md`, `llms.txt`, and `.github/copilot-instructions.md`
+  refreshed for the v1.4.0 surface (19 tools, governance/HITL, annotations, page labels,
+  math lang, prompts).
+
+## Deferred by design
+
+- **`redact_pdf`** stays deferred. pdfnative v1.5.0's annotation writer can only *overlay*
+  content; an overlay-only "redaction" would leave the original bytes intact and create
+  **false security**, which fails this project's honesty bar. It is intentionally **not**
+  shipped and is tracked as an upstream true content-removal feature request (a fitting
+  first use of `draft_governance_issue`). An encrypted-PDF round-trip likewise remains
+  blocked on an upstream Standard Security Handler writer.
+
+## Security & privacy
+
+- **No network, ever.** `draft_governance_issue` is network-free by construction: there is
+  no HTTP client, no GitHub SDK, and no `fetch` anywhere in the server. It cannot open,
+  edit, comment on, or submit an issue/PR — it returns a local draft and stops.
+- **Sandbox reuse.** `outputMode: 'file'` drafts are written through the same
+  `resolveSandboxedPath()` guards as PDF output (relative path, no traversal, no NUL,
+  enforced `.md` extension) inside `PDFNATIVE_MCP_OUTPUT_DIR`.
+- **No key/cert echo, no telemetry** — unchanged from prior releases.
+
+## Upgrade guide
+
+Everything is opt-in and backward-compatible:
+
+1. Bump your dependency to `^1.4.0` — no code changes required; all v1.3.0 calls work
+   unchanged and default responses are byte-identical.
+2. **To draft an upstream issue:** search existing issues, then call
+   `draft_governance_issue` with a `reproduction` and `duplicateSearchPerformed: true`.
+   Present the returned `draftMarkdown` + `compliance` to the user; a **human** submits it.
+   Read the `governance_contract` / `draft_issue_workflow` prompts first.
+3. **To annotate a PDF for review:** call `annotate_pdf` with `{ type, page, rect, contents }`
+   entries. Remember it overlays — it does **not** redact.
+4. **For math symbols:** add the explicit `math` script to `add_international_text`
+   (`lang: ['latin', 'math']`).
+5. **Page labels:** `inspect_pdf` now returns `pageLabels[]` when the PDF declares them.
+
+## Error codes
+
+| `code` | Raised by | Meaning / fix |
+|--------|-----------|---------------|
+| `GOVERNANCE_VIOLATION` | `draft_governance_issue` | The draft breaks the AI-governance contract (proposes a runtime dependency, omits a reproduction, or `duplicateSearchPerformed:false`). Fix the draft and retry. |
+| `ENCRYPTED_SOURCE` | `annotate_pdf` | The source PDF is encrypted. Decrypt it outside the server first. |
+
+## Compatibility
+
+Backward-compatible minor release. Tool names, required inputs, error codes, and default
+response shapes for the existing 17 tools are unchanged from v1.3.0. The two new tools, the
+optional `inspect_pdf.pageLabels` output field, the new `math` lang value, the `prompts`
+capability, and the `GOVERNANCE_VIOLATION` error are all additive (`_meta.apiVersion` →
+`1.4.0` per [`docs/API_STABILITY.md`](../docs/API_STABILITY.md) §3).
+
+## Acknowledgements
+
+Built on [pdfnative v1.5.0](https://github.com/Nizoka/pdfnative) and its new annotation
+writer and page-label reader, and on the pdfnative AI-governance / HITL contract.

--- a/scripts/verify-issue.mjs
+++ b/scripts/verify-issue.mjs
@@ -1,0 +1,107 @@
+/**
+ * pdfnative-mcp — Draft Issue Verifier
+ * ====================================
+ * Validates a locally-drafted issue markdown against the project's AI
+ * governance policy (.github/ai-governance.json) BEFORE a human reviews and
+ * submits it. This is a guardrail, never an autonomous submitter.
+ *
+ * Checks:
+ *   1. No external runtime-dependency requests (install commands / additions to
+ *      a `dependencies` block) — enforces the zero-dependency policy.
+ *   2. A reproduction code block (fenced ``` … ```) is present.
+ *   3. (Advisory) The required issue fields are documented.
+ *
+ * Usage:  npm run verify:issue -- .github/drafts/my-issue.md
+ *         node scripts/verify-issue.mjs .github/drafts/my-issue.md
+ * Exit:   0 on pass, 1 on policy violation, 2 on usage/IO error.
+ *
+ * The canonical validation logic lives in src/governance.ts (used by the
+ * `draft_governance_issue` MCP tool and unit tests); this CLI mirror keeps the
+ * repo's `npm run verify:issue` workflow dependency-free and build-independent.
+ * tests/governance.test.ts asserts the two implementations stay aligned.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/** Patterns that indicate an external runtime dependency is being proposed. */
+const DEPENDENCY_PATTERNS = [
+    /\bnpm\s+(install|i|add)\s+(?!--)[a-z@]/i,
+    /\b(yarn|pnpm|bun)\s+add\s+/i,
+    /\bpnpm\s+install\s+[a-z@]/i,
+    /add\s+[`"']?[\w@/-]+[`"']?\s+to\s+(the\s+)?(runtime\s+)?dependencies\b/i,
+    /"dependencies"\s*:\s*\{[^}]*[\w-]+[^}]*\}/i,
+];
+
+/** Required issue fields (advisory — surfaced as warnings when missing). */
+const REQUIRED_FIELDS = [
+    { key: 'minimal_reproduction', re: /repro|reproduc/i },
+    { key: 'environment', re: /environment|version|node|os\b/i },
+    { key: 'expected_behavior', re: /expected/i },
+];
+
+/**
+ * Validate the text of a draft issue.
+ *
+ * @param {string} content Raw markdown.
+ * @returns {{ ok: boolean, errors: string[], warnings: string[] }}
+ */
+export function validateIssueMarkdown(content) {
+    const errors = [];
+    const warnings = [];
+
+    for (const re of DEPENDENCY_PATTERNS) {
+        if (re.test(content)) {
+            errors.push('Proposing an external runtime dependency violates the zero-dependency policy.');
+            break;
+        }
+    }
+
+    const hasCodeBlock = /```[\s\S]*?```/.test(content);
+    if (!hasCodeBlock) {
+        errors.push('No reproduction code block found — include a minimal repro inside a fenced ``` block.');
+    }
+
+    for (const field of REQUIRED_FIELDS) {
+        if (!field.re.test(content)) {
+            warnings.push(`Recommended field appears to be missing: ${field.key}.`);
+        }
+    }
+
+    return { ok: errors.length === 0, errors, warnings };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────
+
+function main(argv) {
+    const path = argv[2];
+    if (!path) {
+        console.error('Usage: node scripts/verify-issue.mjs <draft.md>');
+        return 2;
+    }
+
+    let content;
+    try {
+        content = readFileSync(path, 'utf8');
+    } catch (err) {
+        console.error(`Cannot read "${path}": ${err instanceof Error ? err.message : String(err)}`);
+        return 2;
+    }
+
+    const { ok, errors, warnings } = validateIssueMarkdown(content);
+
+    for (const w of warnings) console.warn(`warning: ${w}`);
+    if (!ok) {
+        for (const e of errors) console.error(`error: ${e}`);
+        console.error('Issue validation FAILED. A human must resolve these before submission.');
+        return 1;
+    }
+
+    console.log('Issue validation passed. Reminder: this draft must be reviewed and submitted by a human under their own GitHub identity.');
+    return 0;
+}
+
+// Run only when invoked directly (keeps the module import-safe for tests).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+    process.exit(main(process.argv));
+}

--- a/scripts/verify-issue.mjs
+++ b/scripts/verify-issue.mjs
@@ -41,10 +41,20 @@ const REQUIRED_FIELDS = [
 ];
 
 /**
+ * The outcome of validating a draft issue against the governance policy.
+ * Mirrors the `IssueValidationResult` interface in src/governance.ts.
+ *
+ * @typedef {Object} IssueValidationResult
+ * @property {boolean}  ok       True when no blocking policy errors were found.
+ * @property {string[]} errors   Blocking policy violations (empty when `ok`).
+ * @property {string[]} warnings Non-blocking advisories (e.g. missing fields).
+ */
+
+/**
  * Validate the text of a draft issue.
  *
  * @param {string} content Raw markdown.
- * @returns {{ ok: boolean, errors: string[], warnings: string[] }}
+ * @returns {IssueValidationResult}
  */
 export function validateIssueMarkdown(content) {
     const errors = [];

--- a/server.json
+++ b/server.json
@@ -1,19 +1,19 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.Nizoka/pdfnative-mcp",
-  "description": "Production-grade MCP server for PDF generation, PDF/A archival, PDF/UA structural validation, digital signatures (PAdES sign + verify, constant-time node:crypto), page-tree ops (merge / split / extract), Factur-X invoices, and PDF introspection. 17 tools, 24 scripts, zero runtime dependencies beyond pdfnative and the MCP SDK.",
+  "description": "Production-grade MCP server for PDF generation, PDF/A archival, PDF/UA structural validation, digital signatures (PAdES sign + verify, constant-time node:crypto), page-tree ops (merge / split / extract), markup annotations, Factur-X invoices, PDF introspection, and human-in-the-loop AI-governance issue drafting. 19 tools, 24 scripts, zero runtime dependencies beyond pdfnative and the MCP SDK.",
   "repository": {
     "url": "https://github.com/Nizoka/pdfnative-mcp",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "websiteUrl": "https://github.com/Nizoka/pdfnative-mcp#readme",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "pdfnative-mcp",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "transport": { "type": "stdio" },
       "runtimeHint": "npx",
       "runtimeArguments": [

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -21,3 +21,21 @@ export class SecurityError extends ToolError {
         super('SECURITY_VIOLATION', message);
     }
 }
+
+/**
+ * Custom error for AI-governance / human-in-the-loop policy violations raised
+ * by `draft_governance_issue` (code `GOVERNANCE_VIOLATION`).
+ *
+ * The server never opens GitHub issues; it only produces a local, compliant
+ * draft. This error fires when a would-be draft breaks the non-negotiable
+ * governance contract (proposing a runtime dependency, missing a local
+ * reproduction, or skipping the duplicate search) so the human reviewer is
+ * forced to fix the draft before they submit it under their own identity.
+ */
+export class GovernanceError extends ToolError {
+    public override readonly name: string = 'GovernanceError';
+
+    public constructor(message: string) {
+        super('GOVERNANCE_VIOLATION', message);
+    }
+}

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared helpers for loading pdfnative's bundled Noto font-data modules from
+ * disk and registering them with pdfnative's font system.
+ *
+ * The font data modules ship under `pdfnative/fonts/*.js`. We resolve them via
+ * the package entrypoint and a filesystem path (rather than a bare subpath
+ * import) so the loader is robust across bundlers and ESM subpath-resolution
+ * quirks, matching the approach used since v0.3.0.
+ */
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Resolve pdfnative's bundled fonts directory. Walks up from the resolved
+ * package entrypoint (`dist/index.*`) to the package root, then into `fonts/`.
+ */
+export function getFontsDir(): string {
+    const requireFn = createRequire(import.meta.url);
+    const entryPath = requireFn.resolve('pdfnative');
+    return path.resolve(path.dirname(entryPath), '..', 'fonts');
+}
+
+/** Lazily import a Noto font data module from disk and unwrap a `default` export if present. */
+export async function importFontModule(fontFile: string): Promise<unknown> {
+    const fileUrl = pathToFileURL(path.join(getFontsDir(), fontFile)).href;
+    const mod = (await import(fileUrl)) as Record<string, unknown>;
+    return 'default' in mod ? mod['default'] : mod;
+}

--- a/src/governance.ts
+++ b/src/governance.ts
@@ -1,0 +1,115 @@
+/**
+ * AI-governance & Human-In-The-Loop (HITL) contract for pdfnative-mcp.
+ *
+ * This module is the runtime-embedded, single source of truth for the
+ * governance policy declared in `.github/ai-governance.json` and
+ * `.github/AGENT_RULES.md`. It backs:
+ *   - the `draft_governance_issue` tool (draft assembly + policy validation),
+ *   - the `governance_contract` / `draft_issue_workflow` MCP prompts,
+ *   - `tests/governance.test.ts` (which asserts alignment with the repo files
+ *     and with `scripts/verify-issue.mjs`).
+ *
+ * CRITICAL: nothing here — and nothing anywhere in the server — can submit a
+ * GitHub issue, comment, PR, or make any outbound network call. The agent is a
+ * DRAFTSMAN; the human is the only gate.
+ */
+
+/** Result of validating a draft issue's markdown against the policy. */
+export interface IssueValidationResult {
+    readonly ok: boolean;
+    readonly errors: readonly string[];
+    readonly warnings: readonly string[];
+}
+
+/**
+ * Patterns that indicate an external runtime dependency is being proposed.
+ * Kept byte-identical to `scripts/verify-issue.mjs`.
+ */
+const DEPENDENCY_PATTERNS: readonly RegExp[] = [
+    /\bnpm\s+(install|i|add)\s+(?!--)[a-z@]/i,
+    /\b(yarn|pnpm|bun)\s+add\s+/i,
+    /\bpnpm\s+install\s+[a-z@]/i,
+    /add\s+[`"']?[\w@/-]+[`"']?\s+to\s+(the\s+)?(runtime\s+)?dependencies\b/i,
+    /"dependencies"\s*:\s*\{[^}]*[\w-]+[^}]*\}/i,
+];
+
+/** Required issue fields (advisory — surfaced as warnings when missing). */
+const REQUIRED_FIELDS: ReadonlyArray<{ readonly key: string; readonly re: RegExp }> = [
+    { key: 'minimal_reproduction', re: /repro|reproduc/i },
+    { key: 'environment', re: /environment|version|node|os\b/i },
+    { key: 'expected_behavior', re: /expected/i },
+];
+
+/**
+ * Validate the text of a draft issue against the zero-dependency + reproduction
+ * policy. Pure and filesystem-free so both the tool and unit tests can use it.
+ */
+export function validateIssueMarkdown(content: string): IssueValidationResult {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    for (const re of DEPENDENCY_PATTERNS) {
+        if (re.test(content)) {
+            errors.push('Proposing an external runtime dependency violates the zero-dependency policy.');
+            break;
+        }
+    }
+
+    if (!/```[\s\S]*?```/.test(content)) {
+        errors.push('No reproduction code block found — include a minimal repro inside a fenced ``` block.');
+    }
+
+    for (const field of REQUIRED_FIELDS) {
+        if (!field.re.test(content)) {
+            warnings.push(`Recommended field appears to be missing: ${field.key}.`);
+        }
+    }
+
+    return { ok: errors.length === 0, errors, warnings };
+}
+
+/** The non-negotiable identity reminder shown with every draft. */
+export const IDENTITY_REMINDER =
+    'This draft, if submitted, is published under YOUR GitHub identity. You share ' +
+    'responsibility for its content. Review it fully before you open the issue manually.';
+
+/** The human-in-the-loop gate statement embedded in every compliance report. */
+export const HUMAN_GATE =
+    'DRAFT ONLY. The pdfnative-mcp server never opens, edits, or submits GitHub ' +
+    'issues, comments, PRs, or releases, and makes no outbound network call. A human ' +
+    'MUST explicitly review this draft and submit it themselves.';
+
+/**
+ * Compact, agent-facing summary of the governance contract. Surfaced verbatim by
+ * the `governance_contract` MCP prompt and echoed in server instructions.
+ */
+export const GOVERNANCE_CONTRACT_SUMMARY = `pdfnative-mcp AI Governance & Human-In-The-Loop contract (v1.0.0)
+
+ROLE: You are a DRAFTSMAN, never an autonomous submitter.
+
+NON-NEGOTIABLE RULES
+  1. Zero runtime dependencies — never propose adding an external runtime npm package.
+  2. No duplicates — search open AND closed issues/PRs before drafting.
+  3. Local reproduction — run a minimal repro (tool call or Node/TS snippet) first.
+  4. Byte-identity/schema awareness — keep default output byte-identical; keep JSON Schema + Zod aligned.
+  5. Human-in-the-loop gate — produce a LOCAL draft only; a human reviews and submits.
+  6. Identity integrity — remind the user the issue publishes under their GitHub identity.
+
+THE SERVER ITSELF makes no outbound network call and cannot write to GitHub.
+Use the draft_governance_issue tool to produce a compliant local draft + compliance report,
+then present both to the user and stop. The user is the only gate.`;
+
+/**
+ * Step-by-step HITL workflow. Surfaced by the `draft_issue_workflow` MCP prompt.
+ */
+export const DRAFT_ISSUE_WORKFLOW = `Human-In-The-Loop issue workflow for pdfnative-mcp
+
+1. Detect a bug or improvement while working locally.
+2. Reproduce it: run a minimal MCP tool call or Node/TS snippet and capture the exact command + result.
+3. Confirm zero new runtime dependency is required (a hard blocker otherwise).
+4. Search existing open AND closed issues/PRs for duplicates.
+5. Call draft_governance_issue with the title, summary, issueType, reproduction, expected vs actual, and affected packages.
+6. Present the returned draft markdown AND the compliance report to the user.
+7. STOP. The user reviews, then manually opens the issue on GitHub under their own identity.
+
+The agent never submits. The server never touches the network.`;

--- a/src/output.ts
+++ b/src/output.ts
@@ -63,13 +63,16 @@ export function getOutputSandbox(): string | null {
 /**
  * Resolves a user-supplied file path against the sandbox and ensures it stays within it.
  *
+ * @param userPath  Relative path supplied by the caller.
+ * @param extension Required lower-case file extension including the dot
+ *                  (default `.pdf`; `draft_governance_issue` passes `.md`).
  * @throws {SecurityError} when file output is disabled or the path escapes the sandbox.
  */
-export function resolveSandboxedPath(userPath: string): string {
+export function resolveSandboxedPath(userPath: string, extension = '.pdf'): string {
     const sandbox = getOutputSandbox();
     if (sandbox === null) {
         throw new SecurityError(
-            `File output is disabled. Set ${OUTPUT_DIR_ENV} to an allow-listed directory to enable saving PDFs to disk, or use outputMode='base64'.`,
+            `File output is disabled. Set ${OUTPUT_DIR_ENV} to an allow-listed directory to enable saving files to disk, or use outputMode='base64'.`,
         );
     }
 
@@ -91,8 +94,8 @@ export function resolveSandboxedPath(userPath: string): string {
         throw new SecurityError(`outputPath '${userPath}' escapes the sandbox directory.`);
     }
 
-    if (!resolved.toLowerCase().endsWith('.pdf')) {
-        throw new ToolError('INVALID_EXTENSION', 'outputPath must end with the .pdf extension.');
+    if (!resolved.toLowerCase().endsWith(extension)) {
+        throw new ToolError('INVALID_EXTENSION', `outputPath must end with the ${extension} extension.`);
     }
 
     return resolved;
@@ -240,4 +243,32 @@ export async function emitPdfMulti(
             base64: Buffer.from(bytes).toString('base64'),
         })),
     };
+}
+
+/**
+ * Writes a UTF-8 text artifact (e.g. a Markdown governance draft) to a
+ * sandboxed path. Reuses {@link resolveSandboxedPath} — including its NUL /
+ * absolute-path / traversal / extension guards — so text output enjoys the same
+ * defence-in-depth as PDF output. The write uses the exclusive `wx` flag so an
+ * existing file is never clobbered.
+ *
+ * @throws {ToolError}     `OUTPUT_TOO_LARGE` when the text exceeds the size cap.
+ * @throws {SecurityError} when file output is disabled or the path escapes the sandbox.
+ */
+export async function writeSandboxedText(
+    text: string,
+    outputPath: string,
+    extension = '.md',
+): Promise<{ filePath: string; sizeBytes: number }> {
+    const bytes = Buffer.from(text, 'utf8');
+    if (bytes.byteLength > MAX_OUTPUT_BYTES) {
+        throw new ToolError(
+            'OUTPUT_TOO_LARGE',
+            `The text artifact (${bytes.byteLength} bytes) exceeds the maximum allowed size (${MAX_OUTPUT_BYTES} bytes).`,
+        );
+    }
+    const resolved = resolveSandboxedPath(outputPath, extension);
+    await fs.mkdir(path.dirname(resolved), { recursive: true });
+    await fs.writeFile(resolved, bytes, { flag: 'wx' });
+    return { filePath: resolved, sizeBytes: bytes.byteLength };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,13 +7,22 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
     CallToolRequestSchema,
     ListToolsRequestSchema,
+    ListPromptsRequestSchema,
+    GetPromptRequestSchema,
     type CallToolRequest,
     type CallToolResult,
+    type GetPromptRequest,
+    type GetPromptResult,
 } from '@modelcontextprotocol/sdk/types.js';
 import { initCrypto, initNodeCompression } from 'pdfnative';
 
 import { ToolError } from './errors.js';
 import { getCached, setCached } from './cache.js';
+import { PDFNATIVE_MCP_VERSION } from './version.js';
+import {
+    GOVERNANCE_CONTRACT_SUMMARY,
+    DRAFT_ISSUE_WORKFLOW,
+} from './governance.js';
 import { type OutputResult, type MultiOutputResult } from './output.js';
 import { readFields, readVerbosity, selectFields } from './projection.js';
 import {
@@ -111,10 +120,22 @@ import {
     EXTRACT_PAGES_INPUT_SCHEMA,
     extractPagesTool,
 } from './tools/extract-pages.js';
+import {
+    ANNOTATE_PDF_NAME,
+    ANNOTATE_PDF_INPUT_SCHEMA,
+    annotatePdf,
+} from './tools/annotate-pdf.js';
+import {
+    DRAFT_GOVERNANCE_ISSUE_NAME,
+    DRAFT_GOVERNANCE_ISSUE_INPUT_SCHEMA,
+    DRAFT_GOVERNANCE_ISSUE_OUTPUT_SCHEMA,
+    draftGovernanceIssue,
+    type DraftGovernanceIssueResult,
+} from './tools/draft-governance-issue.js';
 
 // JSON import attribute (Node 22+, TS 5.3+) keeps version in lock-step with package.json.
 // Hardcoded here to keep the build rootDir limited to ./src; tests assert it stays in sync.
-const SERVER_VERSION = '1.3.0';
+const SERVER_VERSION = PDFNATIVE_MCP_VERSION;
 const SERVER_NAME = 'pdfnative-mcp';
 
 /**
@@ -126,7 +147,8 @@ const SERVER_TITLE = 'pdfnative MCP — PDF generation, signing & introspection'
 const SERVER_DESCRIPTION =
     'Production-grade MCP server for PDF generation, PDF/A archival, PDF/UA structural validation, ' +
     'digital signatures (PAdES sign + verify, constant-time node:crypto), page-tree ops (merge / split / extract), ' +
-    'Factur-X invoices, and PDF introspection. 17 tools, 24 scripts, zero runtime dependencies beyond pdfnative and the MCP SDK.';
+    'markup annotations, Factur-X invoices, PDF introspection, and human-in-the-loop AI-governance issue drafting. ' +
+    '19 tools, 24 scripts, zero runtime dependencies beyond pdfnative and the MCP SDK.';
 
 /**
  * Per-tool API version used by the opt-in cache key and by `_meta.apiVersion`.
@@ -134,7 +156,7 @@ const SERVER_DESCRIPTION =
  * make a cached response unsafe to serve. Independent from SERVER_VERSION
  * (which tracks the npm package).
  */
-const TOOL_API_VERSION = '1.3.0';
+const TOOL_API_VERSION = '1.4.0';
 
 /** True when the call's input requests a file-mode output (filesystem side-effect). */
 function isFileOutput(input: unknown): boolean {
@@ -145,6 +167,9 @@ function isFileOutput(input: unknown): boolean {
 
 function dispatchOutput(output: unknown, name: string, input: unknown): CallToolResult {
     if (output !== null && typeof output === 'object') {
+        if ('draftMarkdown' in output && 'compliance' in output) {
+            return buildDraftGovernanceIssueResult(output as DraftGovernanceIssueResult, name);
+        }
         if ('parts' in output && 'count' in output) {
             return buildMultiSuccessResult(output as MultiOutputResult, name);
         }
@@ -241,7 +266,7 @@ interface ToolDefinition {
     };
     /** Minimal MCP `_meta.examples` payload — each entry is a self-contained input. */
     examples?: ReadonlyArray<{ readonly title: string; readonly input: Record<string, unknown> }>;
-    handler: (args: unknown) => Promise<OutputResult | MultiOutputResult | InspectPdfResult | VerifyPdfResult | ExtractTextResult | ValidatePdfResult | ExtractAttachmentsResult>;
+    handler: (args: unknown) => Promise<OutputResult | MultiOutputResult | InspectPdfResult | VerifyPdfResult | ExtractTextResult | ValidatePdfResult | ExtractAttachmentsResult | DraftGovernanceIssueResult>;
 }
 
 const TOOLS: readonly ToolDefinition[] = [
@@ -293,12 +318,13 @@ const TOOLS: readonly ToolDefinition[] = [
         name: ADD_INTERNATIONAL_TEXT_NAME,
         title: 'Add international text',
         description:
-            'Generate a PDF rendering text in any of 24 scripts (Arabic, Hebrew, Thai, CJK, Devanagari, Bengali, Tamil, Telugu, Sinhala, Tibetan, Khmer, Myanmar, Ethiopic, Cyrillic, Greek, Georgian, Armenian, Vietnamese, Turkish, Polish, Latin fallback) with optional COLRv1 colour emoji. BiDi reordering (incl. UAX#9 isolates), Arabic harakat positioning, and complex-script OpenType shaping are handled automatically by the embedded Noto fonts; input is NFC-normalised for maximal glyph coverage and embedded newlines auto-split into paragraphs. Pass `lang` as a single code or an array (e.g. ["ar","emoji"]) for multi-script runs.',
+            'Generate a PDF rendering text in any of 24 scripts (Arabic, Hebrew, Thai, CJK, Devanagari, Bengali, Tamil, Telugu, Sinhala, Tibetan, Khmer, Myanmar, Ethiopic, Cyrillic, Greek, Georgian, Armenian, Vietnamese, Turkish, Polish, Latin fallback) with optional COLRv1 colour emoji and mathematical / technical symbols (the "math" font — Noto Sans Math, ∀ ∃ √ ∑ ∫ ∞ ± ÷ ×). BiDi reordering (incl. UAX#9 isolates), Arabic harakat positioning, and complex-script OpenType shaping are handled automatically by the embedded Noto fonts; input is NFC-normalised for maximal glyph coverage and embedded newlines auto-split into paragraphs. Pass `lang` as a single code or an array (e.g. ["ar","emoji"] or ["latin","math"]) for multi-script / symbol runs.',
         inputSchema: ADD_INTERNATIONAL_TEXT_INPUT_SCHEMA,
         outputSchema: PDF_OUTPUT_SCHEMA,
         annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
         examples: [
             { title: 'Arabic', input: { text: 'مرحبا', lang: 'ar', title: 'Hello in Arabic' } },
+            { title: 'Latin + math symbols', input: { title: 'Math', lang: ['latin', 'math'], paragraphs: ['For all x ∈ ℝ, √(x²) = |x| and ∑ i = n(n+1)/2.'] } },
         ],
         handler: addInternationalText,
     },
@@ -481,11 +507,39 @@ const TOOLS: readonly ToolDefinition[] = [
         ],
         handler: extractPagesTool,
     },
+    {
+        name: ANNOTATE_PDF_NAME,
+        title: 'Annotate PDF (markup / drawing)',
+        description:
+            "Add markup / drawing annotations (ISO 32000-1 §12.5) to an existing PDF via pdfnative v1.5's annotation writer. Non-destructive incremental update: original content is preserved byte-for-byte and each annotation is appended to the target page's /Annots. Types: text (sticky note), highlight | underline | strikeout | squiggly (text-markup), square | circle (shapes), line, freetext. Each annotation needs a 0-based `page` and a `rect` [x1,y1,x2,y2]; line also needs `start`/`end`. Optional per-annotation: contents, color, opacity, title, plus type-specific fields (open/icon, quadPoints, interiorColor/borderWidth, fontSize). Encrypted sources are rejected (ENCRYPTED_SOURCE). NOTE: annotations are visual overlays — they do NOT remove or redact the underlying content.",
+        inputSchema: ANNOTATE_PDF_INPUT_SCHEMA,
+        outputSchema: PDF_OUTPUT_SCHEMA,
+        annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        examples: [
+            { title: 'Highlight a region on page 1', input: { pdfBase64: '<base64>', annotations: [{ page: 0, type: 'highlight', rect: [72, 700, 300, 720], color: '#ffe600', contents: 'Review this' }] } },
+            { title: 'Sticky note + red square', input: { pdfBase64: '<base64>', annotations: [{ page: 0, type: 'text', rect: [520, 700, 540, 720], contents: 'Check figures', icon: 'Note' }, { page: 0, type: 'square', rect: [72, 500, 300, 560], color: '#d00000', borderWidth: 2 }] } },
+        ],
+        handler: annotatePdf,
+    },
+    {
+        name: DRAFT_GOVERNANCE_ISSUE_NAME,
+        title: 'Draft a governance-compliant GitHub issue (HITL)',
+        description:
+            "Produce a LOCAL, governance-compliant GitHub issue draft plus a structured compliance report — and NEVER submit anything. This is the MCP-native embodiment of the pdfnative AI-governance / Human-In-The-Loop contract (.github/ai-governance.json, .github/AGENT_RULES.md): the agent is a DRAFTSMAN, the human is the only gate. The server makes NO outbound network call and has NO GitHub write path. The assembled draft is validated against the zero-dependency + reproduction policy; a violation (proposing a runtime dependency, missing reproduction, or duplicateSearchPerformed=false) throws GOVERNANCE_VIOLATION so the human must fix it before submitting under their own identity. Returns the draft markdown inline by default; outputMode='file' also writes a .md to the sandbox. After calling this, present BOTH the draft and the compliance report to the user, then STOP.",
+        inputSchema: DRAFT_GOVERNANCE_ISSUE_INPUT_SCHEMA,
+        outputSchema: DRAFT_GOVERNANCE_ISSUE_OUTPUT_SCHEMA,
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false },
+        examples: [
+            { title: 'Draft a bug report (never submitted)', input: { title: 'add_table clips descenders on wrapped cells', summary: 'Wrapped table cells clip the descenders of g/j/p/q/y at the default cellPadding.', issueType: 'bug', targetRepo: 'pdfnative', reproduction: { command: "add_table with a wrapped cell containing 'paragraphy'", result: 'The descenders of g/p/y are visibly clipped in the rendered PDF.' }, expectedBehavior: 'Descenders render fully within the cell.', affectedPackages: ['pdfnative'], duplicateSearchPerformed: true } },
+            { title: 'Draft an upstream feature request for true redaction', input: { title: 'Expose a content-removal API for true redaction', summary: 'pdfnative 1.5 can only overlay annotations; a content-stream removal API is needed for genuine redaction.', issueType: 'feature', targetRepo: 'pdfnative', reproduction: { command: 'annotate_pdf overlay then extract_text', result: 'Text under the overlay is still extractable.' }, expectedBehavior: 'A supported API removes the underlying bytes so redacted text is unextractable.', affectedPackages: ['pdfnative', 'pdfnative-mcp'], duplicateSearchPerformed: true } },
+        ],
+        handler: draftGovernanceIssue,
+    },
 ];
 
 const TOOL_INDEX: ReadonlyMap<string, ToolDefinition> = new Map(TOOLS.map((t) => [t.name, t]));
 
-const SERVER_INSTRUCTIONS = `pdfnative-mcp bridges the zero-dependency 'pdfnative' v1.4 library to MCP. API version: 1.3.0 (stable).
+const SERVER_INSTRUCTIONS = `pdfnative-mcp bridges the zero-dependency 'pdfnative' v1.5 library to MCP. API version: 1.4.0 (stable).
 
 DECISION TREE — pick the right tool in one step:
   • Plain document (headings, paragraphs, lists)             → ${GENERATE_BASIC_PDF_NAME}
@@ -494,6 +548,7 @@ DECISION TREE — pick the right tool in one step:
   • Tabular / report data                                    → ${ADD_TABLE_NAME}
   • Interactive form (text fields, checkboxes, dropdowns)    → ${ADD_FORM_NAME}
   • Embed a JPEG/PNG into a PDF                              → ${EMBED_IMAGE_NAME}
+  • Add markup annotations (highlight, note, shapes, line)   → ${ANNOTATE_PDF_NAME}
   • Sign any PDF (auto-injects placeholder)                  → ${SIGN_PDF_NAME}
   • Customize signature placeholder before signing           → ${PREPARE_SIGNATURE_PLACEHOLDER_NAME} → ${SIGN_PDF_NAME}
   • Factur-X / ZUGFeRD invoice or any PDF with attachments   → ${ADD_ATTACHMENT_NAME}   (NOT generate_basic_pdf)
@@ -505,6 +560,12 @@ DECISION TREE — pick the right tool in one step:
   • Validate PDF/UA accessibility structure                  → ${VALIDATE_PDF_NAME}
   • Pull plain text from a PDF                               → ${EXTRACT_TEXT_NAME}
   • Pull embedded files back out (Factur-X XML, side-cars)   → ${EXTRACT_ATTACHMENTS_NAME}
+  • Draft a GitHub issue for human review (never submits)    → ${DRAFT_GOVERNANCE_ISSUE_NAME}
+
+AI-GOVERNANCE & HUMAN-IN-THE-LOOP (non-negotiable):
+  • This server is a DRAFTSMAN, never an autonomous submitter. It makes NO outbound network call and has NO GitHub write path.
+  • To propose a bug/feature/issue, call ${DRAFT_GOVERNANCE_ISSUE_NAME}: it returns a local, policy-checked draft + a compliance report. Present BOTH to the user, then STOP. The user reviews and submits manually under their own GitHub identity.
+  • Never propose adding a runtime dependency (hard blocker, GOVERNANCE_VIOLATION). Search open AND closed issues first (duplicateSearchPerformed must be true). Include a minimal, locally-executed reproduction.
 
 COMMON PITFALLS (read these to avoid retry loops):
   • Barcode 'data' is the RAW payload — do NOT URL-encode URLs. For a QR pointing to https://google.com just pass data: 'https://google.com'.
@@ -514,18 +575,47 @@ COMMON PITFALLS (read these to avoid retry loops):
   • sign_pdf RSA key must be PKCS#1 DER (field 'rsaKeyPkcs1DerBase64'). ECDSA key may be SEC1 or PKCS#8 DER (field 'ecPrivateKeyDerBase64') or the raw 32-byte scalar as 64 hex chars (field 'ecPrivateScalarHex'). DER keys are signed with a native constant-time node:crypto provider; the raw scalar uses the pure-JS path.
   • sign_pdf auto-injects a placeholder when missing — call it directly on ANY PDF unless you specifically need to customize the placeholder.
   • merge_pdfs / split_pdf / extract_pages reject ENCRYPTED PDFs (ENCRYPTED_SOURCE — decrypt first) and ALWAYS drop signatures + AcroForm (a page-tree edit invalidates them). They keep self-contained URI links unless dropAnnotations=true. Page indices/ranges are 0-based. split_pdf returns one PDF per range (file mode writes 'out-1.pdf', 'out-2.pdf', …); extract_pages returns a single PDF.
+  • annotate_pdf adds VISUAL OVERLAY markup only (highlight, sticky note, square/circle, line, freetext) via a non-destructive incremental update; it does NOT remove/redact underlying content (the covered text stays extractable). Encrypted sources are rejected (ENCRYPTED_SOURCE). Each annotation needs a 0-based 'page' and a 'rect' [x1,y1,x2,y2]; 'line' also needs 'start'/'end'.
   • For Factur-X / ZUGFeRD invoices, use add_attachment (PDF/A-3) — generate_basic_pdf cannot embed files.
   • PDF/A: pass pdfA='pdfa2b' for the widest reader compatibility. PDF/A-3 is required when you have attachments.
   • PDF/A text is now robust: embedded newlines ('\\n') in paragraphs are auto-split into separate paragraphs; the Euro sign and other CP-1252 symbols extract correctly (pdfnative 1.3); wrapped table cells get unique per-line MCIDs. Write naturally — no manual workarounds needed.
-  • generate_basic_pdf supports nested lists (a list item may be { text, items: [...] }), a document 'outline' (bookmarks; pass 'auto' to derive from headings) and 'pageLabels' (e.g. roman front-matter then decimal body). All PDF/A-safe.
+  • Math / technical symbols (∀ ∃ √ ∑ ∫ ∞ ± ÷ ×) render via add_international_text with the 'math' font: pass lang:['latin','math'] (or add 'math' to any script list) to route math codepoints to the bundled Noto Sans Math (OFL-1.1).
+  • generate_basic_pdf supports nested lists (a list item may be { text, items: [...] }), a document 'outline' (bookmarks; pass 'auto' to derive from headings) and 'pageLabels' (e.g. roman front-matter then decimal body). All PDF/A-safe. inspect_pdf now surfaces those page labels back as a 'pageLabels' array.
   • add_table supports per-cell 'cellBorders' and 'cellVAlign' (top/middle/bottom) — both engage the document backend. generate_basic_pdf, add_table and add_international_text accept 'viewerPreferences' (reader presentation hints, /ViewerPreferences).
   • add_international_text covers 24 scripts and COLRv1 colour emoji; pass 'lang' as a single code or an array (e.g. ["ar","emoji"]) for multi-script runs. Input is NFC-normalised by default; override with normalize ('NFC'|'NFD'|'NFKC'|'NFKD'|false).
   • generate_basic_pdf and add_table accept an optional text 'watermark' (e.g. { text: 'DRAFT' }). Opacity < 1.0 is rejected under pdfA='pdfa1b' (ISO 19005-1 forbids transparency) — use pdfa2b/2u/3b instead.
   • Round-trip: build an invoice with add_attachment, confirm with inspect_pdf (check:['attachments']), then pull the XML back with extract_attachments (filename:'factur-x.xml').
-  • outputMode='file' is only available when the host sets PDFNATIVE_MCP_OUTPUT_DIR; otherwise PDFs are returned as base64.
+  • outputMode='file' is only available when the host sets PDFNATIVE_MCP_OUTPUT_DIR; otherwise PDFs are returned as base64. draft_governance_issue writes a .md there when outputMode='file'.
   • TOKEN-FRUGAL READS: the read-only tools (inspect_pdf, verify_pdf, validate_pdf, extract_text, extract_attachments) accept verbosity:'summary' for a compact scalar-only verdict (drops large arrays / full text) and fields:[...] for dot-path projection (e.g. fields:['allValid']). Defaults are unchanged (full output). Generated PDFs are returned as an embedded resource block, not duplicated in structuredContent.
 
-Every tool ships JSON-Schema-typed inputs/outputs, _meta.apiVersion = '1.3.0', and worked-example _meta.examples. See docs/AI_GUIDE.md for a longer walk-through.`;
+Every tool ships JSON-Schema-typed inputs/outputs, _meta.apiVersion = '1.4.0', and worked-example _meta.examples. The server also exposes MCP prompts ('governance_contract', 'draft_issue_workflow'). See docs/AI_GUIDE.md for a longer walk-through and docs/guides/AI_GOVERNANCE.md for the HITL contract.`;
+
+function buildDraftGovernanceIssueResult(output: DraftGovernanceIssueResult, toolName: string): CallToolResult {
+    const where = output.outputMode === 'file' ? ` and written to ${output.filePath}` : '';
+    return {
+        content: [
+            {
+                type: 'text',
+                text:
+                    `${toolName}: DRAFT ONLY — not submitted${where}. ` +
+                    `${output.compliance.humanGate} Present the draft and compliance report below to the user; ` +
+                    `they must review and submit it themselves under their own GitHub identity.`,
+            },
+            { type: 'text', text: output.draftMarkdown },
+        ],
+        structuredContent: {
+            title: output.title,
+            issueType: output.issueType,
+            targetRepo: output.targetRepo,
+            outputMode: output.outputMode,
+            ...(output.filePath !== undefined ? { filePath: output.filePath } : {}),
+            sizeBytes: output.sizeBytes,
+            draftMarkdown: output.draftMarkdown,
+            warnings: output.warnings,
+            compliance: output.compliance,
+        },
+    };
+}
 
 function buildInspectResult(output: InspectPdfResult, toolName: string, input: unknown): CallToolResult {
     const full = output as unknown as Record<string, unknown>;
@@ -714,14 +804,65 @@ function buildErrorResult(err: unknown, toolName: string): CallToolResult {
     };
 }
 
+interface PromptDefinition {
+    readonly name: string;
+    readonly title: string;
+    readonly description: string;
+    readonly text: string;
+}
+
+/**
+ * MCP prompts surfacing the AI-governance / Human-In-The-Loop contract so any
+ * client can load the rules and the draft workflow directly. Read-only text;
+ * no arguments, no side effects.
+ */
+const PROMPTS: readonly PromptDefinition[] = [
+    {
+        name: 'governance_contract',
+        title: 'AI-governance & HITL contract',
+        description:
+            'The non-negotiable AI-governance / Human-In-The-Loop contract for pdfnative-mcp: the agent is a draftsman, the human is the only gate, zero runtime dependencies, no autonomous GitHub writes.',
+        text: GOVERNANCE_CONTRACT_SUMMARY,
+    },
+    {
+        name: 'draft_issue_workflow',
+        title: 'Human-in-the-loop issue workflow',
+        description:
+            'Step-by-step workflow for drafting a GitHub issue with the draft_governance_issue tool and handing it to a human for review and submission.',
+        text: DRAFT_ISSUE_WORKFLOW,
+    },
+];
+
+const PROMPT_INDEX: ReadonlyMap<string, PromptDefinition> = new Map(PROMPTS.map((p) => [p.name, p]));
+
 export function createServer(): Server {
     const server = new Server(
         { name: SERVER_NAME, version: SERVER_VERSION, title: SERVER_TITLE, description: SERVER_DESCRIPTION },
         {
-            capabilities: { tools: {} },
+            capabilities: { tools: {}, prompts: {} },
             instructions: SERVER_INSTRUCTIONS,
         },
     );
+
+    server.setRequestHandler(ListPromptsRequestSchema, async () => ({
+        prompts: PROMPTS.map((p) => ({ name: p.name, title: p.title, description: p.description })),
+    }));
+
+    server.setRequestHandler(GetPromptRequestSchema, async (request: GetPromptRequest): Promise<GetPromptResult> => {
+        const prompt = PROMPT_INDEX.get(request.params.name);
+        if (prompt === undefined) {
+            throw new ToolError('UNKNOWN_PROMPT', `Unknown prompt: ${request.params.name}`);
+        }
+        return {
+            description: prompt.description,
+            messages: [
+                {
+                    role: 'user',
+                    content: { type: 'text', text: prompt.text },
+                },
+            ],
+        };
+    });
 
     server.setRequestHandler(ListToolsRequestSchema, async () => ({
         tools: TOOLS.map((t) => ({

--- a/src/tools/add-international-text.ts
+++ b/src/tools/add-international-text.ts
@@ -13,9 +13,6 @@
  * transparently by pdfnative. Input is NFC-normalised so decomposed sequences
  * map to the widest possible glyph coverage.
  */
-import { createRequire } from 'node:module';
-import path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import {
     buildDocumentPDFBytes,
     registerFont,
@@ -26,6 +23,7 @@ import {
 import { z } from 'zod';
 import { emitPdf, type OutputResult } from '../output.js';
 import { ToolError } from '../errors.js';
+import { importFontModule } from '../fonts.js';
 import { splitParagraphSegments } from '../text.js';
 import { PDF_A_ENUM, PdfASchema } from '../pdfa.js';
 import { NORMALIZE_ENUM, NormalizeSchema } from '../normalize.js';
@@ -67,26 +65,12 @@ const LANG_TO_FONT_FILE: Readonly<Record<string, string>> = {
     // COLRv1 colour emoji (pdfnative v1.3.0). Falls back to monochrome glyphs
     // automatically inside pdfnative when a colour table is unavailable.
     emoji: 'noto-color-emoji-data.js',
+    // Mathematical / technical symbols (pdfnative v1.5.0, Noto Sans Math OFL-1.1).
+    // Combine with a base script (e.g. lang: ['latin','math']) to render ∀ ∃ √ ∑ ∫ ∞ ± ÷ ×.
+    math: 'noto-sans-math-data.js',
 };
 
 const SUPPORTED_LANGS = Object.keys(LANG_TO_FONT_FILE) as ReadonlyArray<keyof typeof LANG_TO_FONT_FILE>;
-
-/** Resolve pdfnative's bundled fonts directory in a way that bypasses the package's
- *  `exports` map (the font modules are listed in `files` but not in `exports`). */
-function getFontsDir(): string {
-    const requireFn = createRequire(import.meta.url);
-    // Resolve the package entrypoint (dist/index.*) and walk up to package root.
-    // This avoids resolving a non-exported subpath like `pdfnative/package.json`.
-    const entryPath = requireFn.resolve('pdfnative');
-    return path.resolve(path.dirname(entryPath), '..', 'fonts');
-}
-
-/** Lazily import a Noto font data module from disk and unwrap a default export if present. */
-async function importFontModule(fontFile: string): Promise<unknown> {
-    const fileUrl = pathToFileURL(path.join(getFontsDir(), fontFile)).href;
-    const mod = (await import(fileUrl)) as Record<string, unknown>;
-    return 'default' in mod ? mod['default'] : mod;
-}
 
 const _registered = new Set<string>();
 function ensureFontRegistered(lang: string): void {

--- a/src/tools/annotate-pdf.ts
+++ b/src/tools/annotate-pdf.ts
@@ -1,0 +1,277 @@
+/**
+ * Tool: annotate_pdf
+ *
+ * Adds markup / drawing annotations (ISO 32000-1 §12.5) to an existing PDF using
+ * pdfnative v1.5.0's annotation-writer API (`buildAnnotationBody` +
+ * `PdfModifier.addAnnotation`). Writes are non-destructive incremental updates:
+ * the original content is preserved byte-for-byte and each annotation is
+ * appended to the target page's `/Annots` array.
+ *
+ * Supported types (discriminated by `type`):
+ *   - text                                   — sticky-note (`/Text`)
+ *   - highlight | underline | strikeout | squiggly — text-markup (`/Highlight` …)
+ *   - square | circle                        — shapes
+ *   - line                                   — straight line
+ *   - freetext                               — free-standing text (`/FreeText`)
+ *
+ * Faithful-wrapper notes:
+ *   - Encrypted sources are rejected (`ENCRYPTED_SOURCE`) — decrypt first; the
+ *     incremental writer cannot patch an encrypted object stream safely.
+ *   - `/Contents` and `/T` are safely encoded by pdfnative.
+ */
+import {
+    buildAnnotationBody,
+    createModifier,
+    openPdf,
+    type MarkupAnnotation,
+    type PdfColor,
+    type PdfReader,
+} from 'pdfnative';
+import { z } from 'zod';
+
+import { emitPdf, type OutputResult } from '../output.js';
+import { ToolError } from '../errors.js';
+
+export const ANNOTATE_PDF_NAME = 'annotate_pdf';
+
+const ANNOTATION_TYPES = [
+    'text',
+    'highlight',
+    'underline',
+    'strikeout',
+    'squiggly',
+    'square',
+    'circle',
+    'line',
+    'freetext',
+] as const;
+
+const RECT_SCHEMA = {
+    type: 'array',
+    minItems: 4,
+    maxItems: 4,
+    items: { type: 'number' },
+    description: 'Annotation rectangle [x1, y1, x2, y2] in PDF user-space points.',
+} as const;
+
+const COLOR_SCHEMA = {
+    oneOf: [
+        { type: 'string', description: 'Hex (e.g. "#ffcc00") or PDF operator string ("R G B").' },
+        { type: 'array', minItems: 3, maxItems: 3, items: { type: 'number' }, description: 'RGB tuple, 0.0–1.0.' },
+    ],
+} as const;
+
+export const ANNOTATE_PDF_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['pdfBase64', 'annotations'],
+    properties: {
+        pdfBase64: {
+            type: 'string',
+            minLength: 4,
+            description: 'Base64-encoded source PDF to annotate.',
+        },
+        annotations: {
+            type: 'array',
+            minItems: 1,
+            maxItems: 200,
+            description: 'Markup / drawing annotations to add. Each is attached to a 0-based page index.',
+            items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['page', 'type', 'rect'],
+                properties: {
+                    page: { type: 'integer', minimum: 0, description: '0-based page index to attach the annotation to.' },
+                    type: { type: 'string', enum: [...ANNOTATION_TYPES] },
+                    rect: RECT_SCHEMA,
+                    contents: { type: 'string', description: 'Text content / note body (/Contents).' },
+                    color: { ...COLOR_SCHEMA, description: 'Border / line / icon colour (/C).' },
+                    opacity: { type: 'number', minimum: 0, maximum: 1, description: 'Constant opacity /CA in [0,1].' },
+                    title: { type: 'string', description: 'Author / title (/T).' },
+                    // text
+                    open: { type: 'boolean', description: "type='text': whether the note pop-up starts open." },
+                    icon: { type: 'string', description: "type='text': icon name (Note, Comment, Key, Help, Insert…)." },
+                    // text-markup
+                    quadPoints: {
+                        type: 'array',
+                        items: { type: 'number' },
+                        description: "type=highlight|underline|strikeout|squiggly: 8 numbers per marked region.",
+                    },
+                    // shapes
+                    interiorColor: { ...COLOR_SCHEMA, description: "type=square|circle: interior fill colour (/IC)." },
+                    borderWidth: { type: 'number', minimum: 0, description: "type=square|circle|line: border width in points." },
+                    // line
+                    start: { type: 'array', minItems: 2, maxItems: 2, items: { type: 'number' }, description: "type='line': start point [x, y]." },
+                    end: { type: 'array', minItems: 2, maxItems: 2, items: { type: 'number' }, description: "type='line': end point [x, y]." },
+                    // freetext
+                    fontSize: { type: 'number', minimum: 1, description: "type='freetext': default-appearance font size." },
+                },
+            },
+        },
+        outputMode: { type: 'string', enum: ['base64', 'file'], default: 'base64' },
+        outputPath: { type: 'string' },
+    },
+} as const;
+
+const rectSchema = z.tuple([z.number(), z.number(), z.number(), z.number()]);
+const pointSchema = z.tuple([z.number(), z.number()]);
+const colorSchema = z.union([z.string(), z.tuple([z.number(), z.number(), z.number()])]);
+
+const AnnotationSchema = z
+    .object({
+        page: z.number().int().min(0),
+        type: z.enum(ANNOTATION_TYPES),
+        rect: rectSchema,
+        contents: z.string().optional(),
+        color: colorSchema.optional(),
+        opacity: z.number().min(0).max(1).optional(),
+        title: z.string().optional(),
+        open: z.boolean().optional(),
+        icon: z.string().optional(),
+        quadPoints: z.array(z.number()).optional(),
+        interiorColor: colorSchema.optional(),
+        borderWidth: z.number().min(0).optional(),
+        start: pointSchema.optional(),
+        end: pointSchema.optional(),
+        fontSize: z.number().min(1).optional(),
+    })
+    .superRefine((a, ctx) => {
+        if (a.type === 'line' && (a.start === undefined || a.end === undefined)) {
+            ctx.addIssue({ code: z.ZodIssueCode.custom, message: "type='line' requires both 'start' and 'end'." });
+        }
+    });
+
+const InputSchema = z.object({
+    pdfBase64: z.string().min(4),
+    annotations: z.array(AnnotationSchema).min(1).max(200),
+    outputMode: z.enum(['base64', 'file']).default('base64'),
+    outputPath: z.string().optional(),
+});
+
+type AnnotationInput = z.infer<typeof AnnotationSchema>;
+
+function decodeBase64(value: string): Uint8Array {
+    try {
+        return new Uint8Array(Buffer.from(value, 'base64'));
+    } catch {
+        throw new ToolError('VALIDATION_ERROR', 'pdfBase64 is not valid base64.');
+    }
+}
+
+/** Fields shared by every annotation variant. */
+function baseFields(a: AnnotationInput): {
+    rect: readonly [number, number, number, number];
+    contents?: string;
+    color?: PdfColor;
+    opacity?: number;
+    title?: string;
+} {
+    return {
+        rect: a.rect,
+        ...(a.contents !== undefined ? { contents: a.contents } : {}),
+        ...(a.color !== undefined ? { color: a.color as PdfColor } : {}),
+        ...(a.opacity !== undefined ? { opacity: a.opacity } : {}),
+        ...(a.title !== undefined ? { title: a.title } : {}),
+    };
+}
+
+/** Map a validated input annotation to a typed pdfnative {@link MarkupAnnotation}. */
+function toMarkupAnnotation(a: AnnotationInput): MarkupAnnotation {
+    const base = baseFields(a);
+    switch (a.type) {
+        case 'text':
+            return {
+                type: 'text',
+                ...base,
+                ...(a.open !== undefined ? { open: a.open } : {}),
+                ...(a.icon !== undefined ? { icon: a.icon } : {}),
+            };
+        case 'highlight':
+        case 'underline':
+        case 'strikeout':
+        case 'squiggly':
+            return {
+                type: a.type,
+                ...base,
+                ...(a.quadPoints !== undefined ? { quadPoints: a.quadPoints } : {}),
+            };
+        case 'square':
+        case 'circle':
+            return {
+                type: a.type,
+                ...base,
+                ...(a.interiorColor !== undefined ? { interiorColor: a.interiorColor as PdfColor } : {}),
+                ...(a.borderWidth !== undefined ? { borderWidth: a.borderWidth } : {}),
+            };
+        case 'line':
+            return {
+                type: 'line',
+                ...base,
+                // Presence guaranteed by the superRefine above.
+                start: a.start as readonly [number, number],
+                end: a.end as readonly [number, number],
+                ...(a.borderWidth !== undefined ? { borderWidth: a.borderWidth } : {}),
+            };
+        case 'freetext':
+            return {
+                type: 'freetext',
+                ...base,
+                ...(a.fontSize !== undefined ? { fontSize: a.fontSize } : {}),
+            };
+    }
+}
+
+function isEncrypted(reader: PdfReader): boolean {
+    return reader.trailer.get('Encrypt') !== undefined;
+}
+
+export async function annotatePdf(rawInput: unknown): Promise<OutputResult> {
+    const parsed = InputSchema.safeParse(rawInput);
+    if (!parsed.success) {
+        throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
+    }
+    const input = parsed.data;
+
+    const bytes = decodeBase64(input.pdfBase64);
+    let reader: PdfReader;
+    try {
+        reader = openPdf(bytes);
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new ToolError('PDF_PARSE_FAILED', `Failed to parse PDF: ${message}`);
+    }
+
+    if (isEncrypted(reader)) {
+        throw new ToolError(
+            'ENCRYPTED_SOURCE',
+            'annotate_pdf does not support encrypted PDFs. Decrypt the source outside the server first.',
+        );
+    }
+
+    const pageCount = reader.pageCount;
+    for (const a of input.annotations) {
+        if (a.page >= pageCount) {
+            throw new ToolError(
+                'VALIDATION_ERROR',
+                `annotation page ${a.page} is out of range (document has ${pageCount} page(s), 0-based).`,
+            );
+        }
+    }
+
+    const modifier = createModifier(reader);
+    try {
+        for (const a of input.annotations) {
+            modifier.addAnnotation(a.page, buildAnnotationBody(toMarkupAnnotation(a)));
+        }
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new ToolError('PDF_PARSE_FAILED', `Failed to add annotation: ${message}`);
+    }
+
+    const out = modifier.save();
+
+    return emitPdf(out, {
+        mode: input.outputMode,
+        ...(input.outputPath !== undefined ? { outputPath: input.outputPath } : {}),
+    });
+}

--- a/src/tools/draft-governance-issue.ts
+++ b/src/tools/draft-governance-issue.ts
@@ -117,7 +117,7 @@ export const DRAFT_GOVERNANCE_ISSUE_INPUT_SCHEMA = {
 export const DRAFT_GOVERNANCE_ISSUE_OUTPUT_SCHEMA = {
     type: 'object',
     additionalProperties: false,
-    required: ['title', 'issueType', 'targetRepo', 'outputMode', 'sizeBytes', 'draftMarkdown', 'compliance'],
+    required: ['title', 'issueType', 'targetRepo', 'outputMode', 'sizeBytes', 'draftMarkdown', 'warnings', 'compliance'],
     description:
         'A local, unsubmitted issue draft plus its compliance report. The server NEVER opens the issue — a human must review and submit it.',
     properties: {

--- a/src/tools/draft-governance-issue.ts
+++ b/src/tools/draft-governance-issue.ts
@@ -1,0 +1,341 @@
+/**
+ * Tool: draft_governance_issue
+ *
+ * Produces a LOCAL, governance-compliant GitHub issue draft plus a structured
+ * compliance report — and never submits anything. This is the MCP-native
+ * embodiment of the pdfnative AI-governance / Human-In-The-Loop (HITL) contract
+ * (`.github/ai-governance.json`, `.github/AGENT_RULES.md`): the agent is a
+ * DRAFTSMAN, the human is the only gate.
+ *
+ * Guarantees (by construction, not by policy alone):
+ *   - No outbound network call. No GitHub API. No filesystem access outside the
+ *     opt-in sandbox (`PDFNATIVE_MCP_OUTPUT_DIR`) when `outputMode='file'`.
+ *   - The assembled draft is validated against the zero-dependency + reproduction
+ *     policy; a violation throws `GOVERNANCE_VIOLATION` so the human must fix the
+ *     draft before they submit it under their own identity.
+ *   - An identity reminder and the human-gate statement are always included.
+ */
+import os from 'node:os';
+import { z } from 'zod';
+
+import { GovernanceError, ToolError } from '../errors.js';
+import {
+    HUMAN_GATE,
+    IDENTITY_REMINDER,
+    validateIssueMarkdown,
+} from '../governance.js';
+import { writeSandboxedText } from '../output.js';
+import { PDFNATIVE_MCP_VERSION } from '../version.js';
+
+export const DRAFT_GOVERNANCE_ISSUE_NAME = 'draft_governance_issue';
+
+const ISSUE_TYPES = ['bug', 'feature', 'security', 'docs', 'performance'] as const;
+type IssueType = (typeof ISSUE_TYPES)[number];
+
+export const DRAFT_GOVERNANCE_ISSUE_INPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['title', 'summary', 'issueType', 'reproduction', 'expectedBehavior', 'duplicateSearchPerformed'],
+    properties: {
+        title: {
+            type: 'string',
+            minLength: 8,
+            maxLength: 160,
+            description: 'Concise issue title (imperative, no trailing period).',
+        },
+        summary: {
+            type: 'string',
+            minLength: 16,
+            description: 'One or two paragraphs describing the problem or proposal.',
+        },
+        issueType: {
+            type: 'string',
+            enum: [...ISSUE_TYPES],
+            description: "Issue category: 'bug' | 'feature' | 'security' | 'docs' | 'performance'.",
+        },
+        targetRepo: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 100,
+            default: 'pdfnative-mcp',
+            description:
+                "Destination repository label for the draft (documentation only — the server never contacts it). Typically 'pdfnative-mcp' or 'pdfnative'.",
+        },
+        reproduction: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['command', 'result'],
+            description: 'The minimal, locally-executed reproduction that justifies this issue.',
+            properties: {
+                command: {
+                    type: 'string',
+                    minLength: 1,
+                    description: 'The exact command or MCP tool call you ran.',
+                },
+                result: {
+                    type: 'string',
+                    minLength: 1,
+                    description: 'The observed failure, error, or regression.',
+                },
+            },
+        },
+        expectedBehavior: {
+            type: 'string',
+            minLength: 4,
+            description: 'What you expected to happen instead.',
+        },
+        actualBehavior: {
+            type: 'string',
+            description: "What actually happened (defaults to the reproduction result when omitted).",
+        },
+        affectedPackages: {
+            type: 'array',
+            maxItems: 16,
+            default: ['pdfnative-mcp'],
+            items: { type: 'string', minLength: 1 },
+            description: 'Packages impacted by this issue (e.g. ["pdfnative-mcp"], ["pdfnative"]).',
+        },
+        duplicateSearchPerformed: {
+            type: 'boolean',
+            description:
+                'MUST be true: confirms you searched open AND closed issues/PRs for duplicates before drafting.',
+        },
+        outputMode: {
+            type: 'string',
+            enum: ['inline', 'file'],
+            default: 'inline',
+            description:
+                "'inline' (default) returns the draft markdown in the response. 'file' additionally writes it to the sandbox (requires PDFNATIVE_MCP_OUTPUT_DIR); outputPath must be a relative .md path.",
+        },
+        outputPath: {
+            type: 'string',
+            description: "Relative .md path inside the sandbox (only when outputMode='file').",
+        },
+    },
+} as const;
+
+export const DRAFT_GOVERNANCE_ISSUE_OUTPUT_SCHEMA = {
+    type: 'object',
+    additionalProperties: false,
+    required: ['title', 'issueType', 'targetRepo', 'outputMode', 'sizeBytes', 'draftMarkdown', 'compliance'],
+    description:
+        'A local, unsubmitted issue draft plus its compliance report. The server NEVER opens the issue — a human must review and submit it.',
+    properties: {
+        title: { type: 'string' },
+        issueType: { type: 'string', enum: [...ISSUE_TYPES] },
+        targetRepo: { type: 'string' },
+        outputMode: { type: 'string', enum: ['inline', 'file'] },
+        filePath: { type: 'string', description: "Sandboxed absolute path (when outputMode='file')." },
+        sizeBytes: { type: 'integer', minimum: 0 },
+        draftMarkdown: { type: 'string', description: 'The full draft, ready for a human to review and submit.' },
+        warnings: { type: 'array', items: { type: 'string' } },
+        compliance: {
+            type: 'object',
+            additionalProperties: false,
+            required: [
+                'zeroDependencyConfirmed',
+                'reproductionCommand',
+                'reproductionResult',
+                'duplicateSearchPerformed',
+                'affectedPackages',
+                'identityReminderShown',
+                'humanGate',
+                'environment',
+            ],
+            properties: {
+                zeroDependencyConfirmed: { type: 'boolean' },
+                reproductionCommand: { type: 'string' },
+                reproductionResult: { type: 'string' },
+                duplicateSearchPerformed: { type: 'boolean' },
+                affectedPackages: { type: 'array', items: { type: 'string' } },
+                identityReminderShown: { type: 'boolean' },
+                humanGate: { type: 'string' },
+                environment: {
+                    type: 'object',
+                    additionalProperties: false,
+                    required: ['node', 'os', 'pdfnativeMcp'],
+                    properties: {
+                        node: { type: 'string' },
+                        os: { type: 'string' },
+                        pdfnativeMcp: { type: 'string' },
+                    },
+                },
+            },
+        },
+    },
+} as const;
+
+const InputSchema = z.object({
+    title: z.string().min(8).max(160),
+    summary: z.string().min(16),
+    issueType: z.enum(ISSUE_TYPES),
+    targetRepo: z.string().min(1).max(100).default('pdfnative-mcp'),
+    reproduction: z.object({
+        command: z.string().min(1),
+        result: z.string().min(1),
+    }),
+    expectedBehavior: z.string().min(4),
+    actualBehavior: z.string().optional(),
+    affectedPackages: z.array(z.string().min(1)).max(16).default(['pdfnative-mcp']),
+    duplicateSearchPerformed: z.boolean(),
+    outputMode: z.enum(['inline', 'file']).default('inline'),
+    outputPath: z.string().optional(),
+});
+
+export interface ComplianceReport {
+    readonly zeroDependencyConfirmed: boolean;
+    readonly reproductionCommand: string;
+    readonly reproductionResult: string;
+    readonly duplicateSearchPerformed: boolean;
+    readonly affectedPackages: readonly string[];
+    readonly identityReminderShown: boolean;
+    readonly humanGate: string;
+    readonly environment: { readonly node: string; readonly os: string; readonly pdfnativeMcp: string };
+}
+
+export interface DraftGovernanceIssueResult {
+    readonly title: string;
+    readonly issueType: IssueType;
+    readonly targetRepo: string;
+    readonly outputMode: 'inline' | 'file';
+    readonly filePath?: string;
+    readonly sizeBytes: number;
+    readonly draftMarkdown: string;
+    readonly warnings: readonly string[];
+    readonly compliance: ComplianceReport;
+}
+
+/** Assemble the governance-compliant issue markdown. */
+function buildDraftMarkdown(
+    input: z.infer<typeof InputSchema>,
+    environment: ComplianceReport['environment'],
+): string {
+    const actual = input.actualBehavior ?? input.reproduction.result;
+    const lines: string[] = [
+        `# ${input.title}`,
+        '',
+        `> **Type:** ${input.issueType} · **Target:** ${input.targetRepo}`,
+        '',
+        '## Summary',
+        '',
+        input.summary,
+        '',
+        '## Minimal reproduction',
+        '',
+        'Command / tool call:',
+        '',
+        '```',
+        input.reproduction.command,
+        '```',
+        '',
+        'Result:',
+        '',
+        '```',
+        input.reproduction.result,
+        '```',
+        '',
+        '## Expected behavior',
+        '',
+        input.expectedBehavior,
+        '',
+        '## Actual behavior',
+        '',
+        actual,
+        '',
+        '## Environment',
+        '',
+        `- Node: ${environment.node}`,
+        `- OS: ${environment.os}`,
+        `- pdfnative-mcp: ${environment.pdfnativeMcp}`,
+        `- Affected packages: ${input.affectedPackages.join(', ')}`,
+        '',
+        '## Compliance',
+        '',
+        '- [x] Zero new runtime dependency proposed',
+        `- [${input.duplicateSearchPerformed ? 'x' : ' '}] Searched open and closed issues/PRs for duplicates`,
+        '- [x] Minimal reproduction executed locally',
+        '- [x] Expected vs actual documented',
+        '',
+        '---',
+        '',
+        `> ${IDENTITY_REMINDER}`,
+        '',
+        `> ${HUMAN_GATE}`,
+        '',
+    ];
+    return lines.join('\n');
+}
+
+export async function draftGovernanceIssue(rawInput: unknown): Promise<DraftGovernanceIssueResult> {
+    const parsed = InputSchema.safeParse(rawInput);
+    if (!parsed.success) {
+        throw new ToolError('VALIDATION_ERROR', `Invalid arguments: ${parsed.error.message}`);
+    }
+    const input = parsed.data;
+
+    if (!input.duplicateSearchPerformed) {
+        throw new GovernanceError(
+            'duplicateSearchPerformed must be true — search open AND closed issues/PRs for duplicates before drafting.',
+        );
+    }
+
+    if (input.outputMode === 'file' && input.outputPath === undefined) {
+        throw new ToolError('MISSING_OUTPUT_PATH', "outputPath is required when outputMode='file'.");
+    }
+
+    const environment: ComplianceReport['environment'] = {
+        node: process.version,
+        os: `${process.platform} ${os.release()}`,
+        pdfnativeMcp: PDFNATIVE_MCP_VERSION,
+    };
+
+    const draftMarkdown = buildDraftMarkdown(input, environment);
+
+    // Validate the assembled draft against the governance policy. A dependency
+    // proposal or a missing reproduction block is a hard blocker.
+    const validation = validateIssueMarkdown(draftMarkdown);
+    if (!validation.ok) {
+        throw new GovernanceError(
+            `Draft violates the AI-governance contract: ${validation.errors.join(' ')} Fix the draft before it can be reviewed for submission.`,
+        );
+    }
+
+    const compliance: ComplianceReport = {
+        zeroDependencyConfirmed: true,
+        reproductionCommand: input.reproduction.command,
+        reproductionResult: input.reproduction.result,
+        duplicateSearchPerformed: input.duplicateSearchPerformed,
+        affectedPackages: input.affectedPackages,
+        identityReminderShown: true,
+        humanGate: HUMAN_GATE,
+        environment,
+    };
+
+    const sizeBytes = Buffer.byteLength(draftMarkdown, 'utf8');
+
+    if (input.outputMode === 'file') {
+        const { filePath } = await writeSandboxedText(draftMarkdown, input.outputPath as string, '.md');
+        return {
+            title: input.title,
+            issueType: input.issueType,
+            targetRepo: input.targetRepo,
+            outputMode: 'file',
+            filePath,
+            sizeBytes,
+            draftMarkdown,
+            warnings: validation.warnings,
+            compliance,
+        };
+    }
+
+    return {
+        title: input.title,
+        issueType: input.issueType,
+        targetRepo: input.targetRepo,
+        outputMode: 'inline',
+        sizeBytes,
+        draftMarkdown,
+        warnings: validation.warnings,
+        compliance,
+    };
+}

--- a/src/tools/inspect-pdf.ts
+++ b/src/tools/inspect-pdf.ts
@@ -122,6 +122,22 @@ export const INSPECT_PDF_OUTPUT_SCHEMA = {
                 },
             },
         },
+        pageLabels: {
+            type: 'array',
+            description:
+                'Logical page-numbering ranges from the /PageLabels number tree (ISO 32000-1 §12.4.2), or absent when the document has none. Each range gives the 0-based first page, numbering style, optional prefix and start value.',
+            items: {
+                type: 'object',
+                additionalProperties: false,
+                required: ['startPage'],
+                properties: {
+                    startPage: { type: 'integer', minimum: 0 },
+                    style: { type: 'string', enum: ['decimal', 'roman', 'Roman', 'alpha', 'Alpha', 'none'] },
+                    prefix: { type: 'string' },
+                    start: { type: 'integer' },
+                },
+            },
+        },
         checks: {
             type: 'object',
             additionalProperties: { type: 'boolean' },
@@ -156,6 +172,12 @@ export interface InspectPdfResult {
     readonly attachments: readonly AttachmentSummary[];
     readonly info: Readonly<Record<string, string>>;
     readonly perPage?: ReadonlyArray<{ readonly index: number; readonly width: number; readonly height: number }>;
+    readonly pageLabels?: ReadonlyArray<{
+        readonly startPage: number;
+        readonly style?: 'decimal' | 'roman' | 'Roman' | 'alpha' | 'Alpha' | 'none';
+        readonly prefix?: string;
+        readonly start?: number;
+    }>;
     readonly checks?: Readonly<Record<CheckValue, boolean>>;
     readonly checksPassed?: boolean;
 }
@@ -301,6 +323,18 @@ function detectPdfAClaim(reader: PdfReader): string | null {
     return `${part}${conf}`;
 }
 
+/** Read the /PageLabels number tree (pdfnative v1.5.0), or undefined when absent. */
+function readPageLabels(reader: PdfReader): InspectPdfResult['pageLabels'] {
+    const labels = reader.getPageLabels();
+    if (labels === null || labels.length === 0) return undefined;
+    return labels.map((r) => ({
+        startPage: r.startPage,
+        ...(r.style !== undefined ? { style: r.style } : {}),
+        ...(r.prefix !== undefined ? { prefix: r.prefix } : {}),
+        ...(r.start !== undefined ? { start: r.start } : {}),
+    }));
+}
+
 function readPerPage(reader: PdfReader): InspectPdfResult['perPage'] {
     const pages = reader.getPages();
     return pages.map((page, index) => {
@@ -343,6 +377,7 @@ export async function inspectPdf(rawInput: unknown): Promise<InspectPdfResult> {
     const info = readInfoDict(reader);
     const { count: signatureCount, hasPlaceholder } = inspectSignatures(reader);
     const attachments = readAttachments(reader);
+    const pageLabels = readPageLabels(reader);
 
     const result: {
         -readonly [K in keyof InspectPdfResult]: InspectPdfResult[K];
@@ -356,6 +391,10 @@ export async function inspectPdf(rawInput: unknown): Promise<InspectPdfResult> {
         attachments,
         info,
     };
+
+    if (pageLabels !== undefined) {
+        result.pageLabels = pageLabels;
+    }
 
     if (includePages) {
         result.perPage = readPerPage(reader);

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,9 @@
+/**
+ * Single source of truth for the pdfnative-mcp package version.
+ *
+ * Kept in lock-step with package.json and server.json (asserted by
+ * tests/metadata.test.ts). Centralised here so both server.ts and the
+ * governance tooling reference one constant without importing package.json
+ * (the build rootDir is limited to ./src).
+ */
+export const PDFNATIVE_MCP_VERSION = '1.4.0';

--- a/tests/annotate-pdf.test.ts
+++ b/tests/annotate-pdf.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for `annotate_pdf` (pdfnative v1.5 annotation-writer wrapper).
+ */
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { annotatePdf } from '../src/tools/annotate-pdf.js';
+import { ensureCompressionReady } from '../src/server.js';
+import { ToolError } from '../src/errors.js';
+import { assertValidPdf } from './_pdf-assert.js';
+import { makePdfBase64, makeEncryptedPdfBase64 } from './_pagetree-fixtures.js';
+
+const ENV_KEY = 'PDFNATIVE_MCP_OUTPUT_DIR';
+
+describe('annotate_pdf', () => {
+    beforeAll(async () => {
+        delete process.env[ENV_KEY];
+        await ensureCompressionReady();
+    });
+
+    afterEach(() => {
+        delete process.env[ENV_KEY];
+    });
+
+    it('adds a highlight annotation and keeps the page count', async () => {
+        const src = await makePdfBase64(1, 'Doc');
+        const result = await annotatePdf({
+            pdfBase64: src,
+            annotations: [{ page: 0, type: 'highlight', rect: [72, 700, 300, 720], color: '#ffe600', contents: 'note' }],
+        });
+        expect(result.mode).toBe('base64');
+        assertValidPdf(result.base64 as string, 1);
+        // Incremental update grows the file.
+        expect(result.sizeBytes).toBeGreaterThan(0);
+    });
+
+    it('supports every annotation type in a single call', async () => {
+        const src = await makePdfBase64(2, 'Doc');
+        const result = await annotatePdf({
+            pdfBase64: src,
+            annotations: [
+                { page: 0, type: 'text', rect: [520, 700, 540, 720], contents: 'note', icon: 'Note', open: false },
+                { page: 0, type: 'highlight', rect: [72, 700, 300, 720], quadPoints: [72, 720, 300, 720, 72, 700, 300, 700] },
+                { page: 0, type: 'underline', rect: [72, 680, 300, 690] },
+                { page: 0, type: 'strikeout', rect: [72, 660, 300, 670] },
+                { page: 0, type: 'squiggly', rect: [72, 640, 300, 650] },
+                { page: 1, type: 'square', rect: [72, 500, 300, 560], color: [0.8, 0, 0], interiorColor: '#ffeeee', borderWidth: 2 },
+                { page: 1, type: 'circle', rect: [72, 400, 300, 460] },
+                { page: 1, type: 'line', rect: [72, 300, 300, 300], start: [72, 300], end: [300, 300], borderWidth: 1 },
+                { page: 1, type: 'freetext', rect: [72, 200, 300, 240], contents: 'Free text', fontSize: 11 },
+            ],
+        });
+        assertValidPdf(result.base64 as string, 2);
+    });
+
+    it('rejects an out-of-range page index with VALIDATION_ERROR', async () => {
+        const src = await makePdfBase64(1, 'Doc');
+        await expect(
+            annotatePdf({ pdfBase64: src, annotations: [{ page: 5, type: 'highlight', rect: [0, 0, 10, 10] }] }),
+        ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    });
+
+    it("requires 'start' and 'end' for a line annotation", async () => {
+        const src = await makePdfBase64(1, 'Doc');
+        await expect(
+            annotatePdf({ pdfBase64: src, annotations: [{ page: 0, type: 'line', rect: [0, 0, 10, 10] }] }),
+        ).rejects.toMatchObject({ code: 'VALIDATION_ERROR' });
+    });
+
+    it('rejects an empty annotations array', async () => {
+        const src = await makePdfBase64(1, 'Doc');
+        await expect(annotatePdf({ pdfBase64: src, annotations: [] })).rejects.toThrow(ToolError);
+    });
+
+    it('rejects an encrypted source with ENCRYPTED_SOURCE', async () => {
+        const enc = makeEncryptedPdfBase64();
+        await expect(
+            annotatePdf({ pdfBase64: enc, annotations: [{ page: 0, type: 'highlight', rect: [0, 0, 10, 10] }] }),
+        ).rejects.toMatchObject({ code: 'ENCRYPTED_SOURCE' });
+    });
+
+    it('rejects a malformed PDF with PDF_PARSE_FAILED', async () => {
+        const notPdf = Buffer.from('this is not a pdf at all').toString('base64');
+        await expect(
+            annotatePdf({ pdfBase64: notPdf, annotations: [{ page: 0, type: 'highlight', rect: [0, 0, 10, 10] }] }),
+        ).rejects.toMatchObject({ code: 'PDF_PARSE_FAILED' });
+    });
+
+    it('writes to a sandboxed file when outputMode=file', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pdfnative-annotate-'));
+        process.env[ENV_KEY] = dir;
+        const src = await makePdfBase64(1, 'Doc');
+        const result = await annotatePdf({
+            pdfBase64: src,
+            annotations: [{ page: 0, type: 'highlight', rect: [72, 700, 300, 720] }],
+            outputMode: 'file',
+            outputPath: 'annotated.pdf',
+        });
+        expect(result.mode).toBe('file');
+        expect(result.filePath?.startsWith(dir)).toBe(true);
+        const bytes = await fs.readFile(result.filePath as string);
+        assertValidPdf(new Uint8Array(bytes), 1);
+    });
+});

--- a/tests/draft-governance-issue.test.ts
+++ b/tests/draft-governance-issue.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for `draft_governance_issue` — the MCP-native Human-In-The-Loop
+ * embodiment of the pdfnative AI-governance contract. These tests assert the
+ * server acts strictly as a DRAFTSMAN: it produces a compliant local draft plus
+ * a compliance report and NEVER submits anything.
+ */
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { draftGovernanceIssue } from '../src/tools/draft-governance-issue.js';
+import { ToolError } from '../src/errors.js';
+
+const ENV_KEY = 'PDFNATIVE_MCP_OUTPUT_DIR';
+
+const validInput = {
+    title: 'add_table clips descenders on wrapped cells',
+    summary: 'Wrapped table cells clip the descenders of g/j/p/q/y at the default cellPadding.',
+    issueType: 'bug' as const,
+    targetRepo: 'pdfnative',
+    reproduction: { command: "add_table with a wrapped cell containing 'paragraphy'", result: 'Descenders are clipped.' },
+    expectedBehavior: 'Descenders render fully within the cell.',
+    affectedPackages: ['pdfnative'],
+    duplicateSearchPerformed: true,
+};
+
+describe('draft_governance_issue', () => {
+    beforeAll(() => {
+        delete process.env[ENV_KEY];
+    });
+    afterEach(() => {
+        delete process.env[ENV_KEY];
+        vi.restoreAllMocks();
+    });
+
+    it('produces a compliant draft with a reproduction block and identity reminder', async () => {
+        const result = await draftGovernanceIssue(validInput);
+        expect(result.outputMode).toBe('inline');
+        expect(result.draftMarkdown).toContain('# add_table clips descenders on wrapped cells');
+        // Reproduction fenced block present.
+        expect(/```[\s\S]*?```/.test(result.draftMarkdown)).toBe(true);
+        // Identity + human gate surfaced.
+        expect(result.draftMarkdown).toMatch(/GitHub identity/i);
+        expect(result.draftMarkdown).toMatch(/DRAFT ONLY/i);
+        expect(result.sizeBytes).toBeGreaterThan(0);
+    });
+
+    it('returns a complete, honest compliance report', async () => {
+        const { compliance } = await draftGovernanceIssue(validInput);
+        expect(compliance.zeroDependencyConfirmed).toBe(true);
+        expect(compliance.duplicateSearchPerformed).toBe(true);
+        expect(compliance.identityReminderShown).toBe(true);
+        expect(compliance.reproductionCommand).toBe(validInput.reproduction.command);
+        expect(compliance.reproductionResult).toBe(validInput.reproduction.result);
+        expect(compliance.affectedPackages).toEqual(['pdfnative']);
+        expect(compliance.humanGate).toMatch(/never opens/i);
+        expect(compliance.environment.node).toBe(process.version);
+        expect(compliance.environment.pdfnativeMcp).toBe('1.4.0');
+        expect(typeof compliance.environment.os).toBe('string');
+    });
+
+    it('makes NO outbound network call (fetch is never invoked)', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch');
+        await draftGovernanceIssue(validInput);
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects a draft that proposes a runtime dependency with GOVERNANCE_VIOLATION', async () => {
+        await expect(
+            draftGovernanceIssue({
+                ...validInput,
+                summary: 'We should run npm install left-pad to fix this quickly.',
+            }),
+        ).rejects.toMatchObject({ code: 'GOVERNANCE_VIOLATION' });
+    });
+
+    it('rejects duplicateSearchPerformed=false with GOVERNANCE_VIOLATION', async () => {
+        await expect(
+            draftGovernanceIssue({ ...validInput, duplicateSearchPerformed: false }),
+        ).rejects.toMatchObject({ code: 'GOVERNANCE_VIOLATION' });
+    });
+
+    it('rejects invalid input with VALIDATION_ERROR', async () => {
+        await expect(draftGovernanceIssue({ title: 'too short' })).rejects.toMatchObject({
+            code: 'VALIDATION_ERROR',
+        });
+    });
+
+    it("requires outputPath when outputMode='file'", async () => {
+        await expect(
+            draftGovernanceIssue({ ...validInput, outputMode: 'file' }),
+        ).rejects.toThrow(ToolError);
+    });
+
+    it('writes a .md draft to the sandbox when outputMode=file', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pdfnative-gov-'));
+        process.env[ENV_KEY] = dir;
+        const result = await draftGovernanceIssue({
+            ...validInput,
+            outputMode: 'file',
+            outputPath: 'drafts/issue.md',
+        });
+        expect(result.outputMode).toBe('file');
+        expect(result.filePath?.startsWith(dir)).toBe(true);
+        const written = await fs.readFile(result.filePath as string, 'utf8');
+        expect(written).toBe(result.draftMarkdown);
+    });
+
+    it("rejects a non-.md sandbox path with INVALID_EXTENSION", async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pdfnative-gov-'));
+        process.env[ENV_KEY] = dir;
+        await expect(
+            draftGovernanceIssue({ ...validInput, outputMode: 'file', outputPath: 'issue.txt' }),
+        ).rejects.toMatchObject({ code: 'INVALID_EXTENSION' });
+    });
+
+    it('rejects a path-traversal sandbox path with SECURITY_VIOLATION', async () => {
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pdfnative-gov-'));
+        process.env[ENV_KEY] = dir;
+        await expect(
+            draftGovernanceIssue({ ...validInput, outputMode: 'file', outputPath: '../escape.md' }),
+        ).rejects.toMatchObject({ code: 'SECURITY_VIOLATION' });
+    });
+});

--- a/tests/fonts.test.ts
+++ b/tests/fonts.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for math-symbol rendering (pdfnative v1.5 'math' font) exposed as an
+ * explicit `lang` in add_international_text, plus the shared font-dir helper.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { ensureCompressionReady } from '../src/server.js';
+import { getFontsDir } from '../src/fonts.js';
+import { addInternationalText, ADD_INTERNATIONAL_TEXT_INPUT_SCHEMA } from '../src/tools/add-international-text.js';
+import { assertValidPdf } from './_pdf-assert.js';
+
+const MATH_TEXT = 'For all x \u2208 \u211d: \u221a(x\u00b2)=|x|, \u2211 i, \u222b f dx, \u221e, \u00b1\u03b5';
+
+describe('math symbols (pdfnative v1.5 math font)', () => {
+    beforeAll(async () => {
+        delete process.env['PDFNATIVE_MCP_OUTPUT_DIR'];
+        await ensureCompressionReady();
+    });
+
+    it("advertises 'math' as a supported lang in the input schema", () => {
+        const langSchema = (ADD_INTERNATIONAL_TEXT_INPUT_SCHEMA.properties as unknown as Record<string, { oneOf?: Array<{ enum?: readonly string[] }> }>).lang;
+        const singleEnum = langSchema.oneOf?.[0]?.enum ?? [];
+        expect(singleEnum).toContain('math');
+    });
+
+    it('renders math symbols via lang:[latin,math] and produces a valid PDF', async () => {
+        const result = await addInternationalText({
+            title: 'Math',
+            lang: ['latin', 'math'],
+            paragraphs: [MATH_TEXT],
+        });
+        expect(result.mode).toBe('base64');
+        assertValidPdf(result.base64 as string, 1);
+    });
+
+    it('embeds the math font (math run is materially larger than latin-only)', async () => {
+        const latinOnly = await addInternationalText({ title: 'M', lang: 'latin', paragraphs: [MATH_TEXT] });
+        const withMath = await addInternationalText({ title: 'M', lang: ['latin', 'math'], paragraphs: [MATH_TEXT] });
+        // Noto Sans Math is a full font program — embedding it clearly grows the file.
+        expect(withMath.sizeBytes).toBeGreaterThan(latinOnly.sizeBytes + 10000);
+    });
+
+    it('exposes a resolvable bundled fonts directory', () => {
+        const dir = getFontsDir();
+        expect(typeof dir).toBe('string');
+        expect(dir.length).toBeGreaterThan(0);
+    });
+});

--- a/tests/governance.test.ts
+++ b/tests/governance.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for the AI-governance contract module and its alignment with the repo's
+ * governance artifacts (.github/ai-governance.json, scripts/verify-issue.mjs).
+ */
+import { describe, it, expect } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+    validateIssueMarkdown,
+    GOVERNANCE_CONTRACT_SUMMARY,
+    DRAFT_ISSUE_WORKFLOW,
+    IDENTITY_REMINDER,
+    HUMAN_GATE,
+} from '../src/governance.js';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CLI = path.join(ROOT, 'scripts', 'verify-issue.mjs');
+
+/** Run the shipped CLI verifier on a draft and return its exit code (0 pass, 1 fail). */
+async function runCliExitCode(draft: string): Promise<number> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pdfnative-verify-'));
+    const file = path.join(dir, 'draft.md');
+    await fs.writeFile(file, draft, 'utf8');
+    try {
+        execFileSync(process.execPath, [CLI, file], { stdio: 'pipe' });
+        return 0;
+    } catch (err) {
+        return (err as { status?: number }).status ?? 1;
+    }
+}
+
+const GOOD_DRAFT = `# Something broke
+
+## Reproduction
+\`\`\`
+node repro.mjs
+\`\`\`
+Environment: node v22, os windows.
+Expected: it should work.
+`;
+
+const DEPENDENCY_DRAFT = `# Add a dependency
+
+Please run npm install left-pad to fix this.
+
+\`\`\`
+repro here
+\`\`\`
+Expected + environment + node.
+`;
+
+const NO_REPRO_DRAFT = `# No repro provided
+
+Expected behavior described but no fenced code block. environment node.
+`;
+
+describe('validateIssueMarkdown', () => {
+    it('passes a well-formed draft', () => {
+        const r = validateIssueMarkdown(GOOD_DRAFT);
+        expect(r.ok).toBe(true);
+        expect(r.errors).toHaveLength(0);
+    });
+
+    it('rejects a draft proposing a runtime dependency', () => {
+        const r = validateIssueMarkdown(DEPENDENCY_DRAFT);
+        expect(r.ok).toBe(false);
+        expect(r.errors.join(' ')).toMatch(/dependency/i);
+    });
+
+    it('rejects a draft with no reproduction code block', () => {
+        const r = validateIssueMarkdown(NO_REPRO_DRAFT);
+        expect(r.ok).toBe(false);
+        expect(r.errors.join(' ')).toMatch(/reproduction/i);
+    });
+
+    it('warns (advisory) when recommended fields are missing', () => {
+        const r = validateIssueMarkdown('# Title\n\n```\nrepro\n```\n');
+        expect(r.ok).toBe(true);
+        expect(r.warnings.length).toBeGreaterThan(0);
+    });
+
+    it('stays aligned with the shipped CLI verifier (scripts/verify-issue.mjs)', async () => {
+        for (const draft of [GOOD_DRAFT, DEPENDENCY_DRAFT, NO_REPRO_DRAFT, '# x\n\n```\ny\n```\n']) {
+            const module = validateIssueMarkdown(draft);
+            const cliExit = await runCliExitCode(draft);
+            expect(cliExit === 0).toBe(module.ok);
+        }
+    });
+});
+
+describe('governance constants', () => {
+    it('surface the draftsman role and the human gate', () => {
+        expect(GOVERNANCE_CONTRACT_SUMMARY).toMatch(/DRAFTSMAN/);
+        expect(DRAFT_ISSUE_WORKFLOW).toMatch(/never submits/i);
+        expect(IDENTITY_REMINDER).toMatch(/GitHub identity/i);
+        expect(HUMAN_GATE).toMatch(/never opens/i);
+    });
+});
+
+describe('repo governance artifacts', () => {
+    it('.github/ai-governance.json encodes the non-negotiable HITL policy', async () => {
+        const raw = await fs.readFile(path.join(ROOT, '.github', 'ai-governance.json'), 'utf8');
+        const contract = JSON.parse(raw) as {
+            policy: Record<string, unknown>;
+            human_in_the_loop: Record<string, unknown>;
+        };
+        expect(contract.policy['automatic_issue_reporting']).toBe(false);
+        expect(contract.policy['autonomous_github_writes_allowed']).toBe(false);
+        expect(contract.policy['human_in_the_loop_mandatory']).toBe(true);
+        expect(contract.policy['runtime_dependencies_allowed']).toBe(false);
+        expect(contract.human_in_the_loop['role_of_agent']).toBe('draftsman');
+    });
+
+    it('ships the AGENT_RULES.md protocol and a drafts staging area', async () => {
+        const rules = await fs.readFile(path.join(ROOT, '.github', 'AGENT_RULES.md'), 'utf8');
+        expect(rules).toMatch(/draftsman/i);
+        expect(rules).toMatch(/human-in-the-loop/i);
+        const draftsReadme = await fs.readFile(path.join(ROOT, '.github', 'drafts', 'README.md'), 'utf8');
+        expect(draftsReadme).toMatch(/staging area/i);
+    });
+});

--- a/tests/inspect-pdf.test.ts
+++ b/tests/inspect-pdf.test.ts
@@ -39,6 +39,33 @@ describe('inspect_pdf', () => {
         expect(out.perPage![0].height).toBeGreaterThan(0);
     });
 
+    it('surfaces authored page labels via getPageLabels (pdfnative v1.5)', async () => {
+        const gen = await generateBasicPdf({
+            title: 'Labelled',
+            pageLabels: [
+                { startPage: 0, style: 'roman' },
+                { startPage: 1, style: 'decimal', start: 1 },
+            ],
+            blocks: [
+                { type: 'heading', text: 'Front', level: 1 },
+                { type: 'pageBreak' },
+                { type: 'heading', text: 'Body', level: 1 },
+            ],
+        });
+        const out = await inspectPdf({ pdfBase64: gen.base64 as string });
+        expect(Array.isArray(out.pageLabels)).toBe(true);
+        expect(out.pageLabels!.length).toBe(2);
+        expect(out.pageLabels![0].startPage).toBe(0);
+        expect(out.pageLabels![0].style).toBe('roman');
+        expect(out.pageLabels![1].style).toBe('decimal');
+    });
+
+    it('omits pageLabels for a document without a /PageLabels tree', async () => {
+        const pdfBase64 = await buildSamplePdf();
+        const out = await inspectPdf({ pdfBase64 });
+        expect(out.pageLabels).toBeUndefined();
+    });
+
     it('counts signature placeholder fields', async () => {
         const placeholder = await prepareSignaturePlaceholder({
             title: 'Needs sig',

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { emitPdf, emitPdfMulti, resolveSandboxedPath, getOutputSandbox } from '../src/output.js';
+import { emitPdf, emitPdfMulti, resolveSandboxedPath, getOutputSandbox, writeSandboxedText } from '../src/output.js';
 import { SecurityError, ToolError } from '../src/errors.js';
 
 const ENV_KEY = 'PDFNATIVE_MCP_OUTPUT_DIR';
@@ -50,6 +50,28 @@ describe('output sandbox', () => {
 
     it('rejects non-pdf extension', () => {
         expect(() => resolveSandboxedPath('foo.exe')).toThrow(ToolError);
+    });
+
+    it('accepts a custom extension for text artifacts', () => {
+        const resolved = resolveSandboxedPath('drafts/issue.md', '.md');
+        expect(resolved.startsWith(sandboxDir)).toBe(true);
+        expect(resolved.toLowerCase().endsWith('.md')).toBe(true);
+    });
+
+    it('writes a sandboxed .md text artifact', async () => {
+        const { filePath, sizeBytes } = await writeSandboxedText('# Draft\n\nbody', 'drafts/issue.md', '.md');
+        expect(filePath.startsWith(sandboxDir)).toBe(true);
+        const written = await fs.readFile(filePath, 'utf8');
+        expect(written).toBe('# Draft\n\nbody');
+        expect(sizeBytes).toBe(Buffer.byteLength('# Draft\n\nbody', 'utf8'));
+    });
+
+    it('rejects a text artifact whose extension does not match', async () => {
+        await expect(writeSandboxedText('x', 'issue.txt', '.md')).rejects.toThrow(ToolError);
+    });
+
+    it('rejects a traversal path for a text artifact', async () => {
+        await expect(writeSandboxedText('x', '../escape.md', '.md')).rejects.toThrow(SecurityError);
     });
 
     it('refuses file output when sandbox is unset', async () => {

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -14,7 +14,7 @@ describe('server', () => {
 
     it('exposes stable metadata', () => {
         expect(__serverMetadata.name).toBe('pdfnative-mcp');
-        expect(__serverMetadata.version).toBe('1.3.0');
+        expect(__serverMetadata.version).toBe('1.4.0');
     });
 
     it('advertises a human-readable title and description in serverInfo (MCP Implementation)', () => {
@@ -23,11 +23,11 @@ describe('server', () => {
         expect(typeof __serverMetadata.title).toBe('string');
         expect(__serverMetadata.title.length).toBeGreaterThan(0);
         expect(__serverMetadata.description).toMatch(/MCP server/i);
-        expect(__serverMetadata.description).toMatch(/17 tools/);
+        expect(__serverMetadata.description).toMatch(/19 tools/);
     });
 
     it('SERVER_INSTRUCTIONS advertises decision tree and pitfalls for AI clients', () => {
-        expect(__serverInstructions).toMatch(/pdfnative.*v1\.4/);
+        expect(__serverInstructions).toMatch(/pdfnative.*v1\.5/);
         expect(__serverInstructions).toContain('DECISION TREE');
         expect(__serverInstructions).toContain('COMMON PITFALLS');
         // Cite each tool by name in the decision tree.
@@ -36,9 +36,36 @@ describe('server', () => {
             'add_form', 'embed_image', 'prepare_signature_placeholder', 'sign_pdf',
             'verify_pdf', 'validate_pdf', 'inspect_pdf', 'add_attachment', 'extract_text',
             'extract_attachments', 'merge_pdfs', 'split_pdf', 'extract_pages',
+            'annotate_pdf', 'draft_governance_issue',
         ]) {
             expect(__serverInstructions).toContain(t);
         }
+    });
+
+    it('exposes MCP prompts for the AI-governance contract and issue workflow', async () => {
+        const server = createServer() as unknown as { _requestHandlers: Map<string, (req: unknown) => Promise<unknown>> };
+
+        const listPrompts = server._requestHandlers.get('prompts/list');
+        expect(listPrompts).toBeDefined();
+        const promptList = (await listPrompts!({ method: 'prompts/list', params: {} })) as {
+            prompts: Array<{ name: string; title?: string; description?: string }>;
+        };
+        const promptNames = promptList.prompts.map((p) => p.name).sort();
+        expect(promptNames).toEqual(['draft_issue_workflow', 'governance_contract']);
+
+        const getPrompt = server._requestHandlers.get('prompts/get');
+        expect(getPrompt).toBeDefined();
+        const got = (await getPrompt!({
+            method: 'prompts/get',
+            params: { name: 'governance_contract' },
+        })) as { messages: Array<{ role: string; content: { type: string; text: string } }> };
+        expect(got.messages[0]?.role).toBe('user');
+        expect(got.messages[0]?.content.text).toMatch(/DRAFTSMAN/);
+
+        // Unknown prompt names are rejected.
+        await expect(
+            getPrompt!({ method: 'prompts/get', params: { name: 'nope' } }),
+        ).rejects.toThrow();
     });
 
     it('lists all tools', async () => {
@@ -57,6 +84,8 @@ describe('server', () => {
             'add_form',
             'add_international_text',
             'add_table',
+            'annotate_pdf',
+            'draft_governance_issue',
             'embed_image',
             'extract_attachments',
             'extract_pages',
@@ -73,7 +102,7 @@ describe('server', () => {
 
         // Every tool advertises _meta.apiVersion and at least one example.
         for (const t of response.tools) {
-            expect(t._meta?.apiVersion).toBe('1.3.0');
+            expect(t._meta?.apiVersion).toBe('1.4.0');
             expect(Array.isArray(t._meta?.examples)).toBe(true);
             expect((t._meta?.examples ?? []).length).toBeGreaterThan(0);
         }


### PR DESCRIPTION
# PR: v1.4.0 — AI governance + HITL, markup annotations, pdfnative 1.5

## Summary

A minor, fully backward-compatible release that extends pdfnative-mcp to **19 tools** and brings the pdfnative **AI-governance / Human-In-The-Loop (HITL)** system to the MCP surface. Adds `draft_governance_issue` — a **local, network-free** GitHub-issue drafter that produces a compliant draft `.md` plus a machine-readable compliance report (the agent is a *draftsman, never an autonomous submitter*: a human is the only gate, and the server makes **zero** GitHub writes and no outbound network call). Adds `annotate_pdf` — markup overlays (highlight, note, underline, strikeout, squiggly, square, circle, line, freetext) via pdfnative 1.5's incremental-update annotation writer (a **visual review layer, not a redaction**). Surfaces `/PageLabels` in `inspect_pdf`, adds an explicit `math` script to `add_international_text` (Noto Sans Math, on demand only — **no** global auto-routing), advertises the MCP **`prompts`** capability, and upgrades the engine to [pdfnative v1.5.0](https://github.com/Nizoka/pdfnative). No breaking changes — all v1.3.0 tool calls work unchanged and default responses are byte-identical.

Full notes: [`release-notes/v1.4.0.md`](../../release-notes/v1.4.0.md).

## Scope

| Phase | Subject |
| --- | --- |
| 0 | Branch + version bump (package.json `1.4.0`, pdfnative pin `^1.5.0`); `src/version.ts` single source of truth |
| 1 | AI governance / HITL: `src/governance.ts` (contract + `validateIssueMarkdown`), `GovernanceError` (`src/errors.ts`), `writeSandboxedText` (`src/output.ts`), `draft_governance_issue` tool, MCP prompts (`governance_contract`, `draft_issue_workflow`), `.github/ai-governance.json` + `AGENT_RULES.md` + `drafts/README.md`, `scripts/verify-issue.mjs` (`npm run verify:issue`) |
| 2 | `annotate_pdf` (markup overlay via pdfnative 1.5 incremental-update writer); `inspect_pdf` `/PageLabels`; `add_international_text` explicit `math` lang via shared `src/fonts.ts` |
| 3 | Server registration (2 tools → 19, prompts capability + `ListPrompts`/`GetPrompt` handlers, dispatch, `SERVER_VERSION`/`apiVersion` → 1.4.0, decision tree); `index.ts`, `server.json` |
| 4 | Examples: `annotate-pdf`, `draft-governance-issue`, `math-symbols`, `page-labels-inspect` |
| 5 | Tests: 4 new suites + extended `server.test.ts` (prompts + 19 tools), `inspect-pdf.test.ts` (pageLabels), `output.test.ts` (.md writer) |
| 6 | Docs: README, AGENTS.md, AI_GUIDE, API_STABILITY, KNOWLEDGE_BASE, LOCAL_TESTING, ROADMAP, llms.txt, copilot-instructions + new `docs/guides/AI_GOVERNANCE.md` |
| 7 | Release: `release-notes/v1.4.0.md`, CHANGELOG mirror, this PR draft |

## Closes

- Roadmap: ships the pdfnative **AI-governance / HITL** system as an MCP-native tool + prompts, and `annotate_pdf` on pdfnative v1.5.0's annotation writer.
- `redact_pdf` stays **deferred by design**: pdfnative 1.5's writer can only *overlay* content, and an overlay-only "redaction" would leave the original bytes intact and create **false security** — it fails this project's honesty bar. Tracked as an upstream true content-removal request (a fitting first use of `draft_governance_issue`). An encrypted-PDF round-trip likewise remains blocked upstream.

## Quality gate

- ✅ `npm run typecheck:all` — 0 errors
- ✅ `npm run lint` — 0 errors (36 pre-existing non-null-assertion warnings in untouched files)
- ✅ `npm run test:coverage` — **355 tests** passing; **90.47** stmts / **79.18** branches / **95.81** funcs / **92.51** lines (≥ vitest thresholds 88 / 75 / 85 / 90)
- ✅ `npm run build` — clean `dist/`
- ✅ `npm run examples:check` — every `examples/*.json` references a live tool; self-contained examples execute and pass structural assertions
- ✅ `npm run verify:issue` — CLI validates a compliant draft and mirrors `src/governance.ts` byte-for-byte

## Changes summary

### Added
- **Tool `draft_governance_issue`** (new, 19th) — assembles a governance-compliant GitHub issue draft plus a structured `compliance` report and returns them; **never submits, no outbound network call**. Inputs: `title`, `issueType` (`bug|feature|security|docs|performance`), `summary`, `reproduction: { command, result }`, `expectedBehavior`, optional `actualBehavior`, `targetRepo` (default `pdfnative-mcp`), `affectedPackages` (default `['pdfnative-mcp']`), `duplicateSearchPerformed` (**must be `true`**), `outputMode` (`'inline'|'file'`) / `outputPath`. Contract breaches (runtime dependency, missing reproduction, `duplicateSearchPerformed:false`) → new `GOVERNANCE_VIOLATION` error.
- **Tool `annotate_pdf`** (new, 18th) — overlay markup annotations (`text`, `highlight`, `underline`, `strikeout`, `squiggly`, `square`, `circle`, `line`, `freetext`) on an existing PDF via pdfnative 1.5's incremental-update annotation writer. 0-based `page` (bounds-checked), `rect: [x1, y1, x2, y2]`, optional `color`/`contents`. Encrypted sources → `ENCRYPTED_SOURCE`. **Visual overlay only — not a redaction.**
- **`inspect_pdf`** — optional `pageLabels[]` output field (`{ startPage, style?, prefix?, start? }`), present only when the PDF declares `/PageLabels` (pdfnative 1.5 `getPageLabels()`).
- **`add_international_text`** — explicit `math` lang code (maps to `noto-sans-math-data.js`, Noto Sans Math), embedded on demand only when requested (e.g. `lang: ['latin', 'math']`) — **no** global auto-routing.
- **MCP prompts** — the server advertises the `prompts` capability with `governance_contract` (the full contract) and `draft_issue_workflow` (the step-by-step recipe), sourced from `src/governance.ts`.
- **`src/governance.ts`** — single source of truth for the governance contract: `validateIssueMarkdown()` (zero-dependency + reproduction-block policy), prompt copy, identity/human-gate constants.
- **`src/version.ts`** — shared `PDFNATIVE_MCP_VERSION` used by the server and the governance tool.
- **`src/fonts.ts`** — shared font-module directory + loader helpers (deduplicated from `add_international_text`).
- **`src/errors.ts`** — `GovernanceError` (`GOVERNANCE_VIOLATION`).
- **`src/output.ts`** — `writeSandboxedText()`; `resolveSandboxedPath()` parameterised on the allowed extension (reuses every existing guard: relative path, no traversal, no NUL, extension enforcement).
- **Governance contract files** — `.github/ai-governance.json` (machine-readable), `.github/AGENT_RULES.md` (agent-and-human protocol), `.github/drafts/README.md`; `scripts/verify-issue.mjs` CLI (`npm run verify:issue`) mirroring `validateIssueMarkdown()`.
- **Docs** — new [`docs/guides/AI_GOVERNANCE.md`](../../docs/guides/AI_GOVERNANCE.md) (HITL contract + `draft_governance_issue` workflow).
- **Examples** — `annotate-pdf.json`, `draft-governance-issue.json`, `math-symbols.json`, `page-labels-inspect.json` (executable, guarded by examples-as-tests).
- **Tests** — `annotate-pdf.test.ts`, `draft-governance-issue.test.ts`, `governance.test.ts` (asserts the tool, the `verify:issue` CLI, and the repo contract files stay aligned), `fonts.test.ts`; extended `server.test.ts` (prompts + 19 tools), `inspect-pdf.test.ts` (`pageLabels`), `output.test.ts` (`.md` writer).

### Changed
- **Dependency:** `pdfnative` `^1.4.0` → `^1.5.0` (additive — annotation writer + page-label reader).
- **MCP `_meta.apiVersion`** bumped `1.3.0` → `1.4.0` on every tool; `SERVER_VERSION`, `server.json` versions, and `package.json` version → `1.4.0`.
- **Server:** `SERVER_DESCRIPTION` and `SERVER_INSTRUCTIONS` extended to **19 tools** (governance decision branch + corrected math note — explicit lang, **not** global auto-routing); `capabilities` now include `prompts`.
- **Tool count assertion** in `tests/server.test.ts` — 17 → 19; prompt assertions added.
- **Docs:** README, `AGENTS.md`, `docs/AI_GUIDE.md`, `docs/API_STABILITY.md`, `docs/KNOWLEDGE_BASE.md`, `docs/guides/LOCAL_TESTING.md`, `ROADMAP.md`, `llms.txt`, and `.github/copilot-instructions.md` refreshed for the 19-tool / pdfnative-1.5 surface.

### Deferred (with rationale)
- **`redact_pdf`** — deferred **by design**. pdfnative 1.5's annotation writer can only *overlay* content; an overlay-only "redaction" would leave the original bytes intact and create false security. Blocked on an upstream true content-removal API.
- **Encrypted-PDF round-trip fixtures** — once pdfnative exposes a Standard Security Handler writer.

## Reviewer checklist

- [x] CHANGELOG.md v1.4.0 entry mirrors `release-notes/v1.4.0.md`
- [x] `package.json` version === `server.json` versions === `SERVER_VERSION` === `src/version.ts` === `1.4.0`
- [x] Tool count assertion in `tests/server.test.ts` equals 19; list includes `annotate_pdf`, `draft_governance_issue`
- [x] Every tool exposes `_meta.apiVersion === '1.4.0'` and a non-empty `_meta.examples` array
- [x] **`draft_governance_issue` makes zero network calls** and never writes to GitHub (no `fetch`/http/child_process/GitHub SDK anywhere); a `fetch` spy assertion covers it
- [x] `draft_governance_issue` rejects a runtime-dependency proposal, a missing reproduction block, and `duplicateSearchPerformed:false` with `GOVERNANCE_VIOLATION`
- [x] `validateIssueMarkdown()` in `src/governance.ts` stays byte-aligned with `scripts/verify-issue.mjs` (asserted by `governance.test.ts`)
- [x] `annotate_pdf` maps all 9 types correctly, bounds-checks `page`, and rejects encrypted sources with `ENCRYPTED_SOURCE` — and is documented as overlay, **not** redaction
- [x] `inspect_pdf` surfaces `pageLabels[]` when present and omits it when absent
- [x] `add_international_text` `math` lang embeds the Noto Sans Math face **only when requested** (no global auto-routing); doc claims match
- [x] MCP `prompts` capability advertised; `ListPrompts`/`GetPrompt` return `governance_contract` + `draft_issue_workflow`
- [x] `writeSandboxedText` reuses the full sandbox guard set (relative path, no traversal, no NUL, `.md` extension); file-mode drafts stay inside `PDFNATIVE_MCP_OUTPUT_DIR`
- [x] `server.json` validates against the MCP registry schema
- [x] No `any` added in `src/`; no new CodeQL alerts
- [x] Test coverage ≥ vitest thresholds (88 / 75 / 85 / 90)

## Notes for the merger

- No breaking changes; minor bump per [`docs/API_STABILITY.md`](../../docs/API_STABILITY.md) §3 (2 new tools + additive optional output field + new enum value + new prompts capability + a tool-scoped new error code).
- `redact_pdf` is intentionally **not** shipped — see the deferral rationale above; do not treat its absence as an oversight.
- Publish is via GitHub Actions Trusted Publishing (OIDC) — no `NPM_TOKEN`.
- GitHub Release title: `v1.4.0 — AI governance + HITL, markup annotations, pdfnative 1.5`.
